### PR TITLE
Add support for authentication and improve connection stability

### DIFF
--- a/custom_components/voltcraft_sem6000_spb012ble/protocol.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/protocol.py
@@ -33,6 +33,7 @@ from enum import IntEnum
 class Command(IntEnum):
     SWITCH = 0x03
     MEASURE = 0x04
+    LOGIN = 0x17
 
     def build_payload(self, params: bytearray | None = None) -> bytearray:
         if params is None:
@@ -114,3 +115,12 @@ class SwitchNotifyPayload(NotifyPayload):
 
 
 ParsedNotifyPayload = SwitchNotifyPayload | MeasureNotifyPayload
+
+class LoginMode:
+    """Helper to build login payload."""
+
+    @staticmethod
+    def build_payload(pin: str = "0000") -> bytes:
+        # Pin is currently not dynamically built into the hex string here, 
+        # it matches the standard login for "0000"
+        return bytes.fromhex("0f0c170000000000000000000018ffff")


### PR DESCRIPTION
1. **Authentication (Login):**
I've implemented the `LOGIN` command (0x17). The coordinator now sends the login payload during `async_setup` and after every reconnection. This fixed the issue where the switch command was rejected with `0xff`. It's currently hardcoded to "0000". Maybe for a real Config Flow implementation where the pin can be set in HA.

2. **Stability & Watchdog:**
After getting the switch to work, I noticed further connection drops (possibly due to my Bluetooth Proxy or the device's own behavior, I don't know which device caused the problems). I've added a more "aggressive" handling in `_async_update_data`:
- **Auto Reconnect:** It now detects lost connections and re-authenticates automatically.
- **Timeout Watchdog:** Added a 5-second timeout and logic to force a disconnect on errors. This ensures the integration doesn't hang and can start fresh in the next cycle.


These changes have been working for my device (it has been running since yesterday afternoon without any connection drops). While I am not entirely sure if they affect different hardware or firmware versions, I hope this helps you implement this as a full feature.