### PR TITLE
Fix total energy by using device history instead of MEASURE payload

### DIFF
--- a/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
@@ -32,23 +32,25 @@ class VoltcraftData:
     """Data from Voltcraft device measurements."""
 
     is_on: bool
-    power: float
-    voltage: float
-    current: float
-    frequency: int
-    power_factor: float | None
-    consumed_energy: float | None
+    power: float  # Watts (converted from mW)
+    voltage: float  # Volts
+    current: float  # Amps (converted from mA)
+    frequency: int  # Hz
+    power_factor: float | None  # 0.0 - 1.0, calculated from P/(V*I)
+    consumed_energy: float | None  # kWh (converted from Wh)
 
     @staticmethod
-    def from_measure_payload(
+    def from_payload(
         payload: MeasureNotifyPayload,
         fallback_consumed_energy_kwh: float | None = None,
-    ) -> "VoltcraftData":
-        power = payload.power / 1000.0
+    ) -> VoltcraftData:
+        power = payload.power / 1000.0  # mW to W
         voltage = float(payload.voltage)
-        current = payload.current / 1000.0
+        current = payload.current / 1000.0  # mA to A
 
+        # Power factor - calculate from P / (V * I)
         apparent_power = voltage * current
+        power_factor: float | None
         if apparent_power > 0:
             power_factor = min(power / apparent_power, 1.0)
         else:
@@ -56,7 +58,7 @@ class VoltcraftData:
 
         consumed_energy = fallback_consumed_energy_kwh
         if payload.consumed_energy is not None and payload.consumed_energy > 0:
-            consumed_energy = payload.consumed_energy / 1000.0
+            consumed_energy = payload.consumed_energy / 1000.0  # Wh to kWh
 
         return VoltcraftData(
             is_on=payload.is_on,
@@ -88,7 +90,10 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
         self._device_name = device_name
         self._latest_data: VoltcraftData | None = None
 
+        # Some notifications can arrive fragmented, especially history responses
         self._notify_buffer = bytearray()
+
+        # Cached accumulated-consumption history from the device
         self._year_history_wh: tuple[int | None, ...] | None = None
         self._last_history_poll = 0.0
         self._history_request_in_flight = False
@@ -123,12 +128,12 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
         if not values:
             return None
 
-        return sum(values) / 1000.0
+        return sum(values) / 1000.0  # Wh to kWh
 
     async def _request_year_history(self) -> None:
         self._history_request_in_flight = True
 
-        # Small delay after MEASURE request to reduce collisions between requests.
+        # Small delay after MEASURE request to reduce collisions between requests
         await asyncio.sleep(0.1)
 
         await self.client.write_gatt_char(
@@ -139,34 +144,36 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
     async def _async_update_data(self) -> VoltcraftData | None:
         """Fetch data from the device.
 
-        This sends a MEASURE command and periodically also requests yearly
-        consumption history to derive a persistent total-energy reading.
+        This sends a measure command and returns the latest data. The actual data update
+        happens asynchronously via a notification handler.
         """
 
         try:
             await self.client.write_gatt_char(COMMAND_UUID, Command.MEASURE.build_payload())
 
+            # Periodically refresh accumulated device history for a persistent
+            # Total Energy value on devices where MEASURE does not provide one
             now = time.monotonic()
             if now - self._last_history_poll >= 300 and not self._history_request_in_flight:
                 self._last_history_poll = now
                 await self._request_year_history()
 
         except BleakError as err:
-            raise UpdateFailed(f"Failed to send command: {err}") from err
+            raise UpdateFailed(f"Failed to send measure command: {err}") from err
 
         return self._latest_data
 
     async def _handle_notify(self, sender: BleakGATTCharacteristic, data: bytearray) -> None:
         """Handle notifications from the device."""
 
-        _LOGGER.debug("Received notification fragment: %s", data.hex())
+        _LOGGER.debug("Received notification: %s", data.hex())
         self._notify_buffer.extend(data)
 
         while True:
             expected = expected_message_length(self._notify_buffer)
             if expected is None:
                 if self._notify_buffer:
-                    _LOGGER.debug("Dropping stray fragment: %s", self._notify_buffer.hex())
+                    _LOGGER.debug("Dropping invalid notification fragment: %s", self._notify_buffer.hex())
                     self._notify_buffer.clear()
                 return
 
@@ -180,7 +187,7 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
 
             match payload:
                 case MeasureNotifyPayload():
-                    self._latest_data = VoltcraftData.from_measure_payload(
+                    self._latest_data = VoltcraftData.from_payload(
                         payload,
                         fallback_consumed_energy_kwh=self._history_total_kwh(),
                     )
@@ -201,6 +208,7 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
                     self._history_request_in_flight = False
 
                 case SwitchNotifyPayload():
+                    # Switch state changed, trigger immediate measure to update data
                     self.hass.create_task(self.async_request_refresh())
 
                 case None:

--- a/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import logging
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, replace
 
 from bleak import BleakClient, BleakGATTCharacteristic
 from bleak.exc import BleakError
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.device_registry import format_mac
@@ -14,10 +15,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import COMMAND_UUID, DEVICE_NAME, DOMAIN, NOTIFY_UUID, SCAN_INTERVAL
 from .protocol import (
     Command,
+    ConsumptionHistoryNotifyPayload,
+    HistoryKind,
     MeasureNotifyPayload,
     NotifyPayload,
     SwitchModes,
     SwitchNotifyPayload,
+    expected_message_length,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -28,26 +32,31 @@ class VoltcraftData:
     """Data from Voltcraft device measurements."""
 
     is_on: bool
-    power: float  # Watts (converted from mW)
-    voltage: float  # Volts
-    current: float  # Amps (converted from mA)
-    frequency: int  # Hz
-    power_factor: float | None  # 0.0 - 1.0, calculated from P/(V*I)
-    consumed_energy: float  # kWh (converted from Wh)
+    power: float
+    voltage: float
+    current: float
+    frequency: int
+    power_factor: float | None
+    consumed_energy: float | None
 
     @staticmethod
-    def from_payload(payload: MeasureNotifyPayload) -> VoltcraftData:
-        power = payload.power / 1000.0  # mW to W
+    def from_measure_payload(
+        payload: MeasureNotifyPayload,
+        fallback_consumed_energy_kwh: float | None = None,
+    ) -> "VoltcraftData":
+        power = payload.power / 1000.0
         voltage = float(payload.voltage)
-        current = payload.current / 1000.0  # mA to A
+        current = payload.current / 1000.0
 
-        # Power factor - calculate from P / (V * I)
         apparent_power = voltage * current
-        power_factor: float | None
         if apparent_power > 0:
             power_factor = min(power / apparent_power, 1.0)
         else:
             power_factor = None
+
+        consumed_energy = fallback_consumed_energy_kwh
+        if payload.consumed_energy is not None and payload.consumed_energy > 0:
+            consumed_energy = payload.consumed_energy / 1000.0
 
         return VoltcraftData(
             is_on=payload.is_on,
@@ -56,7 +65,7 @@ class VoltcraftData:
             current=current,
             frequency=payload.frequency,
             power_factor=power_factor,
-            consumed_energy=payload.consumed_energy / 1000.0,  # Wh to kWh
+            consumed_energy=consumed_energy,
         )
 
 
@@ -78,6 +87,11 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
         self.mac = format_mac(mac)
         self._device_name = device_name
         self._latest_data: VoltcraftData | None = None
+
+        self._notify_buffer = bytearray()
+        self._year_history_wh: tuple[int | None, ...] | None = None
+        self._last_history_poll = 0.0
+        self._history_request_in_flight = False
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -101,36 +115,97 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
         except BleakError as err:
             _LOGGER.debug("Error disconnecting client: %s", err)
 
+    def _history_total_kwh(self) -> float | None:
+        if not self._year_history_wh:
+            return None
+
+        values = [value for value in self._year_history_wh if value is not None]
+        if not values:
+            return None
+
+        return sum(values) / 1000.0
+
+    async def _request_year_history(self) -> None:
+        self._history_request_in_flight = True
+
+        # Small delay after MEASURE request to reduce collisions between requests.
+        await asyncio.sleep(0.1)
+
+        await self.client.write_gatt_char(
+            COMMAND_UUID,
+            Command.CONSUMPTION_YEAR.build_payload(bytearray([0x00, 0x00])),
+        )
+
     async def _async_update_data(self) -> VoltcraftData | None:
         """Fetch data from the device.
 
-        This sends a measure command and returns the latest data.
-        The actual data update happens asynchronously via a notification handler.
+        This sends a MEASURE command and periodically also requests yearly
+        consumption history to derive a persistent total-energy reading.
         """
 
         try:
             await self.client.write_gatt_char(COMMAND_UUID, Command.MEASURE.build_payload())
+
+            now = time.monotonic()
+            if now - self._last_history_poll >= 300 and not self._history_request_in_flight:
+                self._last_history_poll = now
+                await self._request_year_history()
+
         except BleakError as err:
-            raise UpdateFailed(f"Failed to send measure command: {err}") from err
+            raise UpdateFailed(f"Failed to send command: {err}") from err
 
         return self._latest_data
 
     async def _handle_notify(self, sender: BleakGATTCharacteristic, data: bytearray) -> None:
         """Handle notifications from the device."""
-        _LOGGER.debug("Received notification: %s", data.hex())
-        payload = NotifyPayload.from_payload(data)
 
-        match payload:
-            case MeasureNotifyPayload():
-                self._latest_data = VoltcraftData.from_payload(payload)
-                self.async_set_updated_data(self._latest_data)
+        _LOGGER.debug("Received notification fragment: %s", data.hex())
+        self._notify_buffer.extend(data)
 
-            case SwitchNotifyPayload():
-                # Switch state changed, trigger immediate measure to update data
-                self.hass.create_task(self.async_request_refresh())
+        while True:
+            expected = expected_message_length(self._notify_buffer)
+            if expected is None:
+                if self._notify_buffer:
+                    _LOGGER.debug("Dropping stray fragment: %s", self._notify_buffer.hex())
+                    self._notify_buffer.clear()
+                return
 
-            case None:
-                _LOGGER.warning("Unknown payload received: %s", data.hex())
+            if len(self._notify_buffer) < expected:
+                return
+
+            frame = bytearray(self._notify_buffer[:expected])
+            del self._notify_buffer[:expected]
+
+            payload = NotifyPayload.from_payload(frame)
+
+            match payload:
+                case MeasureNotifyPayload():
+                    self._latest_data = VoltcraftData.from_measure_payload(
+                        payload,
+                        fallback_consumed_energy_kwh=self._history_total_kwh(),
+                    )
+                    self.async_set_updated_data(self._latest_data)
+
+                case ConsumptionHistoryNotifyPayload(kind=HistoryKind.YEAR):
+                    self._history_request_in_flight = False
+                    self._year_history_wh = payload.values_wh
+
+                    if self._latest_data is not None:
+                        self._latest_data = replace(
+                            self._latest_data,
+                            consumed_energy=self._history_total_kwh(),
+                        )
+                        self.async_set_updated_data(self._latest_data)
+
+                case ConsumptionHistoryNotifyPayload():
+                    self._history_request_in_flight = False
+
+                case SwitchNotifyPayload():
+                    self.hass.create_task(self.async_request_refresh())
+
+                case None:
+                    self._history_request_in_flight = False
+                    _LOGGER.warning("Unknown payload received: %s", frame.hex())
 
     async def async_send_switch_command(self, mode: SwitchModes) -> None:
         """Send a switch command to the device."""

--- a/custom_components/voltcraft_sem6000_spb012ble/protocol.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/protocol.py
@@ -1,14 +1,32 @@
 """
 Protocol definitions for Voltcraft SEM6000 / SPB012BLE devices.
+Reverse engineered by monitoring communication with an Android app using nRF Connect.
+Not all commands are implemented.
 
-This version keeps the existing live MEASURE parser but also adds support
-for accumulated consumption history notifications:
-- 0x0A: last 23 hours
-- 0x0B: last 30 days
-- 0x0C: last 12 months
+Payload structure:
+- 0x0f * 1          : Header
+- 0xXX * 1          : Length
+- 0xXX * 1          : Command
+- 0x00 * 1          : ?
+- 0xXX * (length-3) : Params
+- 0xXX * 1          : Checksum
+- 0xFF * 2          : ? (part of the checksum??)
 
-The goal is to derive a persistent device-side total energy counter from the
-history path instead of relying on the live MEASURE payload.
+MEASURE notification layout:
+  Byte 0       : is_on (bool)
+  Bytes 1-3    : power (3 bytes, big-endian, milliwatts)
+  Byte 4       : voltage (1 byte, volts)
+  Bytes 5-6    : current (2 bytes, big-endian, milliamps)
+  Byte 7       : frequency (1 byte, Hz)
+  Bytes 8-9    : unknown padding (NOT power_factor)
+  Bytes 10+    : consumed_energy (big-endian, Wh)
+                 14-byte payload (hw v2): 4 bytes
+                 12-byte payload (hw v3): 2 bytes
+
+Accumulated consumption notifications:
+- 0x0A          : last 23 hours
+- 0x0B          : last 30 days
+- 0x0C          : last 12 months
 """
 
 from __future__ import annotations
@@ -24,14 +42,13 @@ class Command(IntEnum):
     CONSUMPTION_MONTH = 0x0B
     CONSUMPTION_YEAR = 0x0C
 
-    def build_payload(self, params: bytes | bytearray | None = None) -> bytearray:
+    def build_payload(self, params: bytearray | None = None) -> bytearray:
         if params is None:
-            params = b""
+            params = bytearray()
 
-        params = bytearray(params)
         length = len(params) + 3
-        checksum = (1 + sum(params) + int(self)) % 256
-        return bytearray([0x0F, length, int(self), 0x00]) + params + bytearray([checksum, 0xFF, 0xFF])
+        checksum = (1 + sum(list(params)) + self) % 256
+        return bytearray([0x0F, length, self, 0x00]) + params + bytearray([checksum, 0xFF, 0xFF])
 
 
 def expected_message_length(buffer: bytes | bytearray) -> int | None:
@@ -60,34 +77,47 @@ class NotifyPayload:
     @staticmethod
     def from_payload(payload: bytearray) -> ParsedNotifyPayload | None:
         if len(payload) < 4 or payload[0] != 0x0F:
+            # Not a valid payload
             return None
 
         expected = expected_message_length(payload)
         if expected is None or len(payload) < expected:
+            # Incomplete payload
             return None
 
         length = payload[1]
         body = payload[2 : length + 2]
+
         params = body[0:-1]
 
+        # # The checksum always seems to be wrong...
+        # checksum = body[-1]
+        # checksumExpected = (1 + sum(list(params))) % 256
+        # if checksum != checksumExpected:
+        #     # Not a valid payload
+        #     return None
+
         if len(params) < 2:
+            # Not enough data for command + status byte
             return None
 
         command = params[0]
+
         arguments = params[2:]
 
         if command == Command.SWITCH:
             return SwitchNotifyPayload.from_data(arguments)
-        if command == Command.MEASURE:
+        elif command == Command.MEASURE:
             return MeasureNotifyPayload.from_data(arguments)
-        if command == Command.CONSUMPTION_DAY:
+        elif command == Command.CONSUMPTION_DAY:
             return ConsumptionHistoryNotifyPayload.from_day(arguments)
-        if command == Command.CONSUMPTION_MONTH:
+        elif command == Command.CONSUMPTION_MONTH:
             return ConsumptionHistoryNotifyPayload.from_month(arguments)
-        if command == Command.CONSUMPTION_YEAR:
+        elif command == Command.CONSUMPTION_YEAR:
             return ConsumptionHistoryNotifyPayload.from_year(arguments)
-
-        return None
+        else:
+            # Unknown command
+            return None
 
 
 @dataclass(frozen=True)
@@ -100,12 +130,15 @@ class MeasureNotifyPayload(NotifyPayload):
     consumed_energy: int | None
 
     @staticmethod
-    def from_data(data: bytearray) -> "MeasureNotifyPayload":
+    def from_data(data: bytearray) -> MeasureNotifyPayload:
         if len(data) < 8:
             raise ValueError(
                 f"Unexpected MEASURE payload length: {len(data)} bytes ({data.hex()})"
             )
 
+        # data[8:10] are unknown padding bytes — skip them
+        # 14-byte payloads may contain total consumption at offset 10;
+        # 12-byte payloads do not provide a usable value on affected devices
         return MeasureNotifyPayload(
             is_on=bool(data[0]),
             power=int.from_bytes(data[1:4], byteorder="big"),
@@ -122,8 +155,9 @@ class ConsumptionHistoryNotifyPayload(NotifyPayload):
     values_wh: tuple[int | None, ...]
 
     @staticmethod
-    def from_day(data: bytearray) -> "ConsumptionHistoryNotifyPayload":
+    def from_day(data: bytearray) -> ConsumptionHistoryNotifyPayload:
         values: list[int | None] = []
+
         for offset in range(0, len(data), 2):
             chunk = data[offset : offset + 2]
             if len(chunk) == 2:
@@ -135,14 +169,15 @@ class ConsumptionHistoryNotifyPayload(NotifyPayload):
         )
 
     @staticmethod
-    def from_month(data: bytearray) -> "ConsumptionHistoryNotifyPayload":
+    def from_month(data: bytearray) -> ConsumptionHistoryNotifyPayload:
         values: list[int | None] = []
+
         for offset in range(0, len(data), 4):
             chunk = data[offset : offset + 4]
             if len(chunk) == 4:
                 values.insert(0, int.from_bytes(chunk[0:3], byteorder="big"))
 
-        # Based on known reverse-engineered parsers, the current day is not included.
+        # Notification does not contain measurement for today
         values.insert(0, None)
 
         return ConsumptionHistoryNotifyPayload(
@@ -151,14 +186,15 @@ class ConsumptionHistoryNotifyPayload(NotifyPayload):
         )
 
     @staticmethod
-    def from_year(data: bytearray) -> "ConsumptionHistoryNotifyPayload":
+    def from_year(data: bytearray) -> ConsumptionHistoryNotifyPayload:
         values: list[int | None] = []
+
         for offset in range(0, len(data), 4):
             chunk = data[offset : offset + 4]
             if len(chunk) == 4:
                 values.insert(0, int.from_bytes(chunk[0:3], byteorder="big"))
 
-        # Based on known reverse-engineered parsers, the current month is not included.
+        # Notification does not contain measurement for current month
         values.insert(0, None)
 
         return ConsumptionHistoryNotifyPayload(
@@ -170,7 +206,7 @@ class ConsumptionHistoryNotifyPayload(NotifyPayload):
 @dataclass(frozen=True)
 class SwitchNotifyPayload(NotifyPayload):
     @staticmethod
-    def from_data(data: bytearray) -> "SwitchNotifyPayload":
+    def from_data(data: bytearray) -> SwitchNotifyPayload:
         return SwitchNotifyPayload()
 
 

--- a/custom_components/voltcraft_sem6000_spb012ble/protocol.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/protocol.py
@@ -1,46 +1,45 @@
 """
 Protocol definitions for Voltcraft SEM6000 / SPB012BLE devices.
-Reverse engineered by monitoring communication with an Android app using nRF Connect.
-Not all commands are implemented.
 
-Payload structure:
-- 0x0f * 1          : Header
-- 0xXX * 1          : Length
-- 0xXX * 1          : Command
-- 0x00 * 1          : ?
-- 0xXX * (length-3) : Params
-- 0xXX * 1          : Checksum
-- 0xFF * 2          : ? (part of the checksum??)
+This version keeps the existing live MEASURE parser but also adds support
+for accumulated consumption history notifications:
+- 0x0A: last 23 hours
+- 0x0B: last 30 days
+- 0x0C: last 12 months
 
-MEASURE notification layout:
-  Byte 0       : is_on (bool)
-  Bytes 1-3    : power (3 bytes, big-endian, milliwatts)
-  Byte 4       : voltage (1 byte, volts)
-  Bytes 5-6    : current (2 bytes, big-endian, milliamps)
-  Byte 7       : frequency (1 byte, Hz)
-  Bytes 8-9    : unknown padding (NOT power_factor)
-  Bytes 10+    : consumed_energy (big-endian, Wh)
-                 14-byte payload (hw v2): 4 bytes
-                 12-byte payload (hw v3): 2 bytes
+The goal is to derive a persistent device-side total energy counter from the
+history path instead of relying on the live MEASURE payload.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import Enum, IntEnum
 
 
 class Command(IntEnum):
     SWITCH = 0x03
     MEASURE = 0x04
+    CONSUMPTION_DAY = 0x0A
+    CONSUMPTION_MONTH = 0x0B
+    CONSUMPTION_YEAR = 0x0C
 
-    def build_payload(self, params: bytearray | None = None) -> bytearray:
+    def build_payload(self, params: bytes | bytearray | None = None) -> bytearray:
         if params is None:
-            params = bytearray()
+            params = b""
 
+        params = bytearray(params)
         length = len(params) + 3
-        checksum = (1 + sum(list(params)) + self) % 256
-        return bytearray([0x0F, length, self, 0x00]) + params + bytearray([checksum, 0xFF, 0xFF])
+        checksum = (1 + sum(params) + int(self)) % 256
+        return bytearray([0x0F, length, int(self), 0x00]) + params + bytearray([checksum, 0xFF, 0xFF])
+
+
+def expected_message_length(buffer: bytes | bytearray) -> int | None:
+    if len(buffer) < 2:
+        return None
+    if buffer[0] != 0x0F:
+        return None
+    return int(buffer[1]) + 4
 
 
 class SwitchModes(IntEnum):
@@ -51,36 +50,44 @@ class SwitchModes(IntEnum):
         return Command.SWITCH.build_payload(bytearray([self]))
 
 
+class HistoryKind(Enum):
+    DAY = "day"
+    MONTH = "month"
+    YEAR = "year"
+
+
 class NotifyPayload:
     @staticmethod
     def from_payload(payload: bytearray) -> ParsedNotifyPayload | None:
-        if payload[0] != 0x0F:
-            # Not a valid payload
+        if len(payload) < 4 or payload[0] != 0x0F:
+            return None
+
+        expected = expected_message_length(payload)
+        if expected is None or len(payload) < expected:
             return None
 
         length = payload[1]
         body = payload[2 : length + 2]
-
         params = body[0:-1]
 
-        # # The checksum always seems to be wrong...
-        # checksum = body[-1]
-        # checksumExpected = (1 + sum(list(params))) % 256
-        # if checksum != checksumExpected:
-        #     # Not a valid payload
-        #     return None
+        if len(params) < 2:
+            return None
 
         command = params[0]
-
         arguments = params[2:]
 
         if command == Command.SWITCH:
             return SwitchNotifyPayload.from_data(arguments)
-        elif command == Command.MEASURE:
+        if command == Command.MEASURE:
             return MeasureNotifyPayload.from_data(arguments)
-        else:
-            # Unknown command
-            return None
+        if command == Command.CONSUMPTION_DAY:
+            return ConsumptionHistoryNotifyPayload.from_day(arguments)
+        if command == Command.CONSUMPTION_MONTH:
+            return ConsumptionHistoryNotifyPayload.from_month(arguments)
+        if command == Command.CONSUMPTION_YEAR:
+            return ConsumptionHistoryNotifyPayload.from_year(arguments)
+
+        return None
 
 
 @dataclass(frozen=True)
@@ -90,27 +97,85 @@ class MeasureNotifyPayload(NotifyPayload):
     voltage: int
     current: int
     frequency: int
-    consumed_energy: int
+    consumed_energy: int | None
 
     @staticmethod
-    def from_data(data: bytearray) -> MeasureNotifyPayload:
-        # data[8:10] are unknown padding bytes — skip them
-        # consumed_energy starts at offset 10; length varies by hw version
+    def from_data(data: bytearray) -> "MeasureNotifyPayload":
+        if len(data) < 8:
+            raise ValueError(
+                f"Unexpected MEASURE payload length: {len(data)} bytes ({data.hex()})"
+            )
+
         return MeasureNotifyPayload(
             is_on=bool(data[0]),
             power=int.from_bytes(data[1:4], byteorder="big"),
             voltage=int(data[4]),
             current=int.from_bytes(data[5:7], byteorder="big"),
             frequency=int(data[7]),
-            consumed_energy=int.from_bytes(data[10:], byteorder="big"),
+            consumed_energy=int.from_bytes(data[10:14], byteorder="big") if len(data) >= 14 else None,
+        )
+
+
+@dataclass(frozen=True)
+class ConsumptionHistoryNotifyPayload(NotifyPayload):
+    kind: HistoryKind
+    values_wh: tuple[int | None, ...]
+
+    @staticmethod
+    def from_day(data: bytearray) -> "ConsumptionHistoryNotifyPayload":
+        values: list[int | None] = []
+        for offset in range(0, len(data), 2):
+            chunk = data[offset : offset + 2]
+            if len(chunk) == 2:
+                values.insert(0, int.from_bytes(chunk, byteorder="big"))
+
+        return ConsumptionHistoryNotifyPayload(
+            kind=HistoryKind.DAY,
+            values_wh=tuple(values),
+        )
+
+    @staticmethod
+    def from_month(data: bytearray) -> "ConsumptionHistoryNotifyPayload":
+        values: list[int | None] = []
+        for offset in range(0, len(data), 4):
+            chunk = data[offset : offset + 4]
+            if len(chunk) == 4:
+                values.insert(0, int.from_bytes(chunk[0:3], byteorder="big"))
+
+        # Based on known reverse-engineered parsers, the current day is not included.
+        values.insert(0, None)
+
+        return ConsumptionHistoryNotifyPayload(
+            kind=HistoryKind.MONTH,
+            values_wh=tuple(values),
+        )
+
+    @staticmethod
+    def from_year(data: bytearray) -> "ConsumptionHistoryNotifyPayload":
+        values: list[int | None] = []
+        for offset in range(0, len(data), 4):
+            chunk = data[offset : offset + 4]
+            if len(chunk) == 4:
+                values.insert(0, int.from_bytes(chunk[0:3], byteorder="big"))
+
+        # Based on known reverse-engineered parsers, the current month is not included.
+        values.insert(0, None)
+
+        return ConsumptionHistoryNotifyPayload(
+            kind=HistoryKind.YEAR,
+            values_wh=tuple(values),
         )
 
 
 @dataclass(frozen=True)
 class SwitchNotifyPayload(NotifyPayload):
     @staticmethod
-    def from_data(data: bytearray) -> SwitchNotifyPayload:
+    def from_data(data: bytearray) -> "SwitchNotifyPayload":
         return SwitchNotifyPayload()
 
 
-ParsedNotifyPayload = SwitchNotifyPayload | MeasureNotifyPayload
+ParsedNotifyPayload = (
+    SwitchNotifyPayload
+    | MeasureNotifyPayload
+    | ConsumptionHistoryNotifyPayload
+)


### PR DESCRIPTION
This fixes Total Energy for devices where the live MEASURE payload does not contain a usable total-energy value.

What changed:
- keep live MEASURE parsing for power/voltage/current/frequency
- add parsing for accumulated consumption history commands
- derive total energy from device-side history instead of the live MEASURE payload
- reassemble fragmented notifications before parsing

Why:
- on affected devices, the MEASURE payload stays at a constant/non-usable value for total energy
- the device itself keeps a persistent energy counter/history even when the app has not been connected for a long time
- therefore Total Energy must be read from the history path, not from the live MEASURE payload

This appears to address issue #2 on affected devices.
This PR addresses the remaining Total Energy issue by reading device-side history data instead of relying on the MEASURE payload.
It builds on the investigation in PR #4, which showed that adjusting offsets in the 12-byte MEASURE payload does not fully solve the problem.

This approach was informed by prior reverse-engineering/protocol work in related SEM6000 projects, especially:
- [moormaster/python3-voltcraft-sem6000](https://github.com/Matthias-pixel/python3-voltcraft-sem6000)
- [Heckie75/voltcraft-sem-6000](https://github.com/Heckie75/voltcraft-sem-6000)

In particular, the history/accumulated-consumption commands pointed toward reading device-side energy history instead of relying only on the live MEASURE payload.

Tested on my device:
- Total Energy in Home Assistant now matches the value shown by the official app
- power/voltage/current/frequency continue to work