### PR TITLE
Fix total energy by using device history instead of MEASURE payload

### DIFF
--- a/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
@@ -145,7 +145,7 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
     async def _async_update_data(self) -> VoltcraftData | None:
         """Fetch data from the device.
 
-        This sends a measure command and returns the latest data. 
+        This sends a measure command and returns the latest data.
         The actual data update happens asynchronously via a notification handler.
         """
 

--- a/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
+import asyncio
 import logging
-from dataclasses import dataclass
+import time
+from dataclasses import dataclass, replace
 
 from bleak import BleakClient, BleakGATTCharacteristic
 from bleak.exc import BleakError
-
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.device_registry import format_mac
@@ -14,10 +15,13 @@ from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, Upda
 from .const import COMMAND_UUID, DEVICE_NAME, DOMAIN, NOTIFY_UUID, SCAN_INTERVAL
 from .protocol import (
     Command,
+    ConsumptionHistoryNotifyPayload,
+    HistoryKind,
     MeasureNotifyPayload,
     NotifyPayload,
     SwitchModes,
     SwitchNotifyPayload,
+    expected_message_length,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -33,10 +37,13 @@ class VoltcraftData:
     current: float  # Amps (converted from mA)
     frequency: int  # Hz
     power_factor: float | None  # 0.0 - 1.0, calculated from P/(V*I)
-    consumed_energy: float  # kWh (converted from Wh)
+    consumed_energy: float | None  # kWh (converted from Wh)
 
     @staticmethod
-    def from_payload(payload: MeasureNotifyPayload) -> VoltcraftData:
+    def from_payload(
+        payload: MeasureNotifyPayload,
+        fallback_consumed_energy_kwh: float | None = None,
+    ) -> VoltcraftData:
         power = payload.power / 1000.0  # mW to W
         voltage = float(payload.voltage)
         current = payload.current / 1000.0  # mA to A
@@ -49,6 +56,10 @@ class VoltcraftData:
         else:
             power_factor = None
 
+        consumed_energy = fallback_consumed_energy_kwh
+        if payload.consumed_energy is not None and payload.consumed_energy > 0:
+            consumed_energy = payload.consumed_energy / 1000.0  # Wh to kWh
+
         return VoltcraftData(
             is_on=payload.is_on,
             power=power,
@@ -56,7 +67,7 @@ class VoltcraftData:
             current=current,
             frequency=payload.frequency,
             power_factor=power_factor,
-            consumed_energy=payload.consumed_energy / 1000.0,  # Wh to kWh
+            consumed_energy=consumed_energy,
         )
 
 
@@ -78,6 +89,14 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
         self.mac = format_mac(mac)
         self._device_name = device_name
         self._latest_data: VoltcraftData | None = None
+
+        # Some notifications can arrive fragmented, especially history responses
+        self._notify_buffer = bytearray()
+
+        # Cached accumulated-consumption history from the device
+        self._year_history_wh: tuple[int | None, ...] | None = None
+        self._last_history_poll = 0.0
+        self._history_request_in_flight = False
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -101,15 +120,44 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
         except BleakError as err:
             _LOGGER.debug("Error disconnecting client: %s", err)
 
+    def _history_total_kwh(self) -> float | None:
+        if not self._year_history_wh:
+            return None
+
+        values = [value for value in self._year_history_wh if value is not None]
+        if not values:
+            return None
+
+        return sum(values) / 1000.0  # Wh to kWh
+
+    async def _request_year_history(self) -> None:
+        self._history_request_in_flight = True
+
+        # Small delay after MEASURE request to reduce collisions between requests
+        await asyncio.sleep(0.1)
+
+        await self.client.write_gatt_char(
+            COMMAND_UUID,
+            Command.CONSUMPTION_YEAR.build_payload(bytearray([0x00, 0x00])),
+        )
+
     async def _async_update_data(self) -> VoltcraftData | None:
         """Fetch data from the device.
 
-        This sends a measure command and returns the latest data.
-        The actual data update happens asynchronously via a notification handler.
+        This sends a measure command and returns the latest data. The actual data update
+        happens asynchronously via a notification handler.
         """
 
         try:
             await self.client.write_gatt_char(COMMAND_UUID, Command.MEASURE.build_payload())
+
+            # Periodically refresh accumulated device history for a persistent
+            # Total Energy value on devices where MEASURE does not provide one
+            now = time.monotonic()
+            if now - self._last_history_poll >= 300 and not self._history_request_in_flight:
+                self._last_history_poll = now
+                await self._request_year_history()
+
         except BleakError as err:
             raise UpdateFailed(f"Failed to send measure command: {err}") from err
 
@@ -117,20 +165,55 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
 
     async def _handle_notify(self, sender: BleakGATTCharacteristic, data: bytearray) -> None:
         """Handle notifications from the device."""
+
         _LOGGER.debug("Received notification: %s", data.hex())
-        payload = NotifyPayload.from_payload(data)
+        self._notify_buffer.extend(data)
 
-        match payload:
-            case MeasureNotifyPayload():
-                self._latest_data = VoltcraftData.from_payload(payload)
-                self.async_set_updated_data(self._latest_data)
+        while True:
+            expected = expected_message_length(self._notify_buffer)
+            if expected is None:
+                if self._notify_buffer:
+                    _LOGGER.debug("Dropping invalid notification fragment: %s", self._notify_buffer.hex())
+                    self._notify_buffer.clear()
+                return
 
-            case SwitchNotifyPayload():
-                # Switch state changed, trigger immediate measure to update data
-                self.hass.create_task(self.async_request_refresh())
+            if len(self._notify_buffer) < expected:
+                return
 
-            case None:
-                _LOGGER.warning("Unknown payload received: %s", data.hex())
+            frame = bytearray(self._notify_buffer[:expected])
+            del self._notify_buffer[:expected]
+
+            payload = NotifyPayload.from_payload(frame)
+
+            match payload:
+                case MeasureNotifyPayload():
+                    self._latest_data = VoltcraftData.from_payload(
+                        payload,
+                        fallback_consumed_energy_kwh=self._history_total_kwh(),
+                    )
+                    self.async_set_updated_data(self._latest_data)
+
+                case ConsumptionHistoryNotifyPayload(kind=HistoryKind.YEAR):
+                    self._history_request_in_flight = False
+                    self._year_history_wh = payload.values_wh
+
+                    if self._latest_data is not None:
+                        self._latest_data = replace(
+                            self._latest_data,
+                            consumed_energy=self._history_total_kwh(),
+                        )
+                        self.async_set_updated_data(self._latest_data)
+
+                case ConsumptionHistoryNotifyPayload():
+                    self._history_request_in_flight = False
+
+                case SwitchNotifyPayload():
+                    # Switch state changed, trigger immediate measure to update data
+                    self.hass.create_task(self.async_request_refresh())
+
+                case None:
+                    self._history_request_in_flight = False
+                    _LOGGER.warning("Unknown payload received: %s", frame.hex())
 
     async def async_send_switch_command(self, mode: SwitchModes) -> None:
         """Send a switch command to the device."""

--- a/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass, replace
 
 from bleak import BleakClient, BleakGATTCharacteristic
 from bleak.exc import BleakError
+
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
 from homeassistant.helpers.device_registry import format_mac
@@ -144,8 +145,8 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
     async def _async_update_data(self) -> VoltcraftData | None:
         """Fetch data from the device.
 
-        This sends a measure command and returns the latest data. The actual data update
-        happens asynchronously via a notification handler.
+        This sends a measure command and returns the latest data. 
+        The actual data update happens asynchronously via a notification handler.
         """
 
         try:

--- a/custom_components/voltcraft_sem6000_spb012ble/protocol.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/protocol.py
@@ -22,17 +22,25 @@ MEASURE notification layout:
   Bytes 10+    : consumed_energy (big-endian, Wh)
                  14-byte payload (hw v2): 4 bytes
                  12-byte payload (hw v3): 2 bytes
+
+Accumulated consumption notifications:
+- 0x0A          : last 23 hours
+- 0x0B          : last 30 days
+- 0x0C          : last 12 months
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass
-from enum import IntEnum
+from enum import Enum, IntEnum
 
 
 class Command(IntEnum):
     SWITCH = 0x03
     MEASURE = 0x04
+    CONSUMPTION_DAY = 0x0A
+    CONSUMPTION_MONTH = 0x0B
+    CONSUMPTION_YEAR = 0x0C
 
     def build_payload(self, params: bytearray | None = None) -> bytearray:
         if params is None:
@@ -43,6 +51,14 @@ class Command(IntEnum):
         return bytearray([0x0F, length, self, 0x00]) + params + bytearray([checksum, 0xFF, 0xFF])
 
 
+def expected_message_length(buffer: bytes | bytearray) -> int | None:
+    if len(buffer) < 2:
+        return None
+    if buffer[0] != 0x0F:
+        return None
+    return int(buffer[1]) + 4
+
+
 class SwitchModes(IntEnum):
     ON = 0x01
     OFF = 0x00
@@ -51,11 +67,22 @@ class SwitchModes(IntEnum):
         return Command.SWITCH.build_payload(bytearray([self]))
 
 
+class HistoryKind(Enum):
+    DAY = "day"
+    MONTH = "month"
+    YEAR = "year"
+
+
 class NotifyPayload:
     @staticmethod
     def from_payload(payload: bytearray) -> ParsedNotifyPayload | None:
-        if payload[0] != 0x0F:
+        if len(payload) < 4 or payload[0] != 0x0F:
             # Not a valid payload
+            return None
+
+        expected = expected_message_length(payload)
+        if expected is None or len(payload) < expected:
+            # Incomplete payload
             return None
 
         length = payload[1]
@@ -70,6 +97,10 @@ class NotifyPayload:
         #     # Not a valid payload
         #     return None
 
+        if len(params) < 2:
+            # Not enough data for command + status byte
+            return None
+
         command = params[0]
 
         arguments = params[2:]
@@ -78,6 +109,12 @@ class NotifyPayload:
             return SwitchNotifyPayload.from_data(arguments)
         elif command == Command.MEASURE:
             return MeasureNotifyPayload.from_data(arguments)
+        elif command == Command.CONSUMPTION_DAY:
+            return ConsumptionHistoryNotifyPayload.from_day(arguments)
+        elif command == Command.CONSUMPTION_MONTH:
+            return ConsumptionHistoryNotifyPayload.from_month(arguments)
+        elif command == Command.CONSUMPTION_YEAR:
+            return ConsumptionHistoryNotifyPayload.from_year(arguments)
         else:
             # Unknown command
             return None
@@ -90,19 +127,79 @@ class MeasureNotifyPayload(NotifyPayload):
     voltage: int
     current: int
     frequency: int
-    consumed_energy: int
+    consumed_energy: int | None
 
     @staticmethod
     def from_data(data: bytearray) -> MeasureNotifyPayload:
+        if len(data) < 8:
+            raise ValueError(
+                f"Unexpected MEASURE payload length: {len(data)} bytes ({data.hex()})"
+            )
+
         # data[8:10] are unknown padding bytes — skip them
-        # consumed_energy starts at offset 10; length varies by hw version
+        # 14-byte payloads may contain total consumption at offset 10;
+        # 12-byte payloads do not provide a usable value on affected devices
         return MeasureNotifyPayload(
             is_on=bool(data[0]),
             power=int.from_bytes(data[1:4], byteorder="big"),
             voltage=int(data[4]),
             current=int.from_bytes(data[5:7], byteorder="big"),
             frequency=int(data[7]),
-            consumed_energy=int.from_bytes(data[10:], byteorder="big"),
+            consumed_energy=int.from_bytes(data[10:14], byteorder="big") if len(data) >= 14 else None,
+        )
+
+
+@dataclass(frozen=True)
+class ConsumptionHistoryNotifyPayload(NotifyPayload):
+    kind: HistoryKind
+    values_wh: tuple[int | None, ...]
+
+    @staticmethod
+    def from_day(data: bytearray) -> ConsumptionHistoryNotifyPayload:
+        values: list[int | None] = []
+
+        for offset in range(0, len(data), 2):
+            chunk = data[offset : offset + 2]
+            if len(chunk) == 2:
+                values.insert(0, int.from_bytes(chunk, byteorder="big"))
+
+        return ConsumptionHistoryNotifyPayload(
+            kind=HistoryKind.DAY,
+            values_wh=tuple(values),
+        )
+
+    @staticmethod
+    def from_month(data: bytearray) -> ConsumptionHistoryNotifyPayload:
+        values: list[int | None] = []
+
+        for offset in range(0, len(data), 4):
+            chunk = data[offset : offset + 4]
+            if len(chunk) == 4:
+                values.insert(0, int.from_bytes(chunk[0:3], byteorder="big"))
+
+        # Notification does not contain measurement for today
+        values.insert(0, None)
+
+        return ConsumptionHistoryNotifyPayload(
+            kind=HistoryKind.MONTH,
+            values_wh=tuple(values),
+        )
+
+    @staticmethod
+    def from_year(data: bytearray) -> ConsumptionHistoryNotifyPayload:
+        values: list[int | None] = []
+
+        for offset in range(0, len(data), 4):
+            chunk = data[offset : offset + 4]
+            if len(chunk) == 4:
+                values.insert(0, int.from_bytes(chunk[0:3], byteorder="big"))
+
+        # Notification does not contain measurement for current month
+        values.insert(0, None)
+
+        return ConsumptionHistoryNotifyPayload(
+            kind=HistoryKind.YEAR,
+            values_wh=tuple(values),
         )
 
 
@@ -113,4 +210,8 @@ class SwitchNotifyPayload(NotifyPayload):
         return SwitchNotifyPayload()
 
 
-ParsedNotifyPayload = SwitchNotifyPayload | MeasureNotifyPayload
+ParsedNotifyPayload = (
+    SwitchNotifyPayload
+    | MeasureNotifyPayload
+    | ConsumptionHistoryNotifyPayload
+)


### PR DESCRIPTION
This fixes Total Energy for devices where the live MEASURE payload does not contain a usable total-energy value.

What changed:
- keep live MEASURE parsing for power/voltage/current/frequency
- add parsing for accumulated consumption history commands
- derive total energy from device-side history instead of the live MEASURE payload
- reassemble fragmented notifications before parsing

Why:
- on affected devices, the MEASURE payload stays at a constant/non-usable value for total energy
- the device itself keeps a persistent energy counter/history even when the app has not been connected for a long time
- therefore Total Energy must be read from the history path, not from the live MEASURE payload

This appears to address issue #2 on affected devices.
This PR addresses the remaining Total Energy issue by reading device-side history data instead of relying on the MEASURE payload.
It builds on the investigation in PR #4, which showed that adjusting offsets in the 12-byte MEASURE payload does not fully solve the problem.

This approach was informed by prior reverse-engineering/protocol work in related SEM6000 projects, especially:
- [moormaster/python3-voltcraft-sem6000](https://github.com/Matthias-pixel/python3-voltcraft-sem6000)
- [Heckie75/voltcraft-sem-6000](https://github.com/Heckie75/voltcraft-sem-6000)

In particular, the history/accumulated-consumption commands pointed toward reading device-side energy history instead of relying only on the live MEASURE payload.

Tested on my device:
- Total Energy in Home Assistant now matches the value shown by the official app
- power/voltage/current/frequency continue to work
