### PR TITLE
Handle transient BLE setup failures as ConfigEntryNotReady

### DIFF
--- a/custom_components/voltcraft_sem6000_spb012ble/__init__.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/__init__.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import asyncio
+
 from bleak import BleakClient
+from bleak.exc import BleakError
 from bleak_retry_connector import establish_connection
 
 from homeassistant.components import bluetooth
@@ -17,28 +20,44 @@ PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     mac_address = entry.data[CONF_MAC]
+
+    client: BleakClient | None = None
+
     ble_device = bluetooth.async_ble_device_from_address(hass, mac_address)
+
     if not ble_device:
         raise ConfigEntryNotReady(f"Device {mac_address} not found")
 
-    client = await establish_connection(
-        BleakClient,
-        ble_device,
-        entry.entry_id,
-    )
+    try:
+        client = await establish_connection(
+            BleakClient,
+            ble_device,
+            entry.entry_id,
+        )
 
-    coord = VoltcraftDataUpdateCoordinator(
-        hass,
-        client,
-        mac_address,
-        ble_device.name,
-    )
+        coord = VoltcraftDataUpdateCoordinator(
+            hass,
+            client,
+            mac_address,
+            ble_device.name,
+        )
 
-    # Setup coordinator (start notifications)
-    await coord.async_setup()
+        # Setup coordinator (start notifications)
+        await coord.async_setup()
 
-    # Perform initial data fetch
-    await coord.async_config_entry_first_refresh()
+        # Perform initial data fetch
+        await coord.async_config_entry_first_refresh()
+
+    except (asyncio.TimeoutError, BleakError) as ex:
+        if client is not None:
+            try:
+                await client.disconnect()
+            except BleakError:
+                pass
+
+        raise ConfigEntryNotReady(
+            f"BLE setup failed for {mac_address}: {ex}"
+        ) from ex
 
     # Store coordinator in hass.data
     hass.data.setdefault(DOMAIN, {})


### PR DESCRIPTION
This change handles transient BLE setup failures during config entry setup.

If establish_connection(), coordinator setup, or the initial BLE setup fails
with a Bleak error or timeout, the integration now raises ConfigEntryNotReady
instead of failing hard. This allows Home Assistant to retry the config entry
automatically.