### PR TITLE
feat: BLE reliability hardening + optional PIN authentication

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -60,3 +60,21 @@ jobs:
 
       - name: Type check with mypy
         run: mypy custom_components/voltcraft_sem6000_spb012ble
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: Install dependencies
+        run: pip install --no-cache-dir -r requirements-dev.txt
+
+      - name: Run tests with pytest
+        run: pytest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,9 +28,10 @@ custom_components/voltcraft_sem6000_spb012ble/
 The integration uses Home Assistant's `DataUpdateCoordinator` pattern for centralized BLE communication:
 
 1. **Coordinator** (`coordinator.py`): `VoltcraftDataUpdateCoordinator`
-   - Owns the BLE connection (established via `bleak-retry-connector`)
-   - Registers persistent notification handler on `NOTIFY_UUID`
-   - Polls device every 5 seconds by sending MEASURE command
+   - Owns and lazily (re)establishes the BLE connection via `_async_ensure_connected()` (the single owner of `establish_connection` + `start_notify`, serialized by an `asyncio.Lock`)
+   - Registers persistent notification handler on `NOTIFY_UUID` on every (re)connect
+   - Polls device every 5 seconds by sending MEASURE command, then awaits the response notification (`MEASURE_TIMEOUT`)
+   - Tolerates up to `MAX_MISSED_UPDATES` consecutive cycles without a measurement before raising `UpdateFailed`; a broken link is torn down and reconnected
    - Processes ALL notifications (solicited and unsolicited) asynchronously
    - Distributes measurement data to all entities atomically
 
@@ -42,7 +43,7 @@ The integration uses Home Assistant's `DataUpdateCoordinator` pattern for centra
 ### BLE Communication Flow
 
 1. **Discovery**: Bluetooth devices discovered via Home Assistant's bluetooth integration using service UUID `0000fff0-0000-1000-8000-00805f9b34fb`
-2. **Connection**: BLE connection established in `__init__.py` using `bleak-retry-connector`
+2. **Connection**: BLE connection established lazily by the coordinator (`_async_ensure_connected`) using `bleak-retry-connector`
 3. **Commands**: Sent via GATT characteristic `COMMAND_UUID` (0xfff3)
 4. **Notifications**: Received via `NOTIFY_UUID` (0xfff4)
 5. **Polling**: Coordinator sends MEASURE command every 5 seconds, device responds via notification
@@ -64,14 +65,15 @@ Commands are built using `Command.build_payload()` and responses parsed via `Not
 **Unit conversions** in `VoltcraftData.from_payload()`:
 - Power: milliwatts → watts (÷1000)
 - Current: milliamps → amps (÷1000)
-- Power factor: 0-256 → 0.0-1.0 (÷256)
-- Voltage, frequency, consumed_energy: no conversion
+- Power factor: calculated as P / (V × I), clamped to 1.0; `None` when V × I is 0
+- Energy: watt-hours → kilowatt-hours (÷1000)
+- Voltage, frequency: no conversion
 
 ### Entity Implementations
 
 **Switch Entity** (`switch.py`): `MainSwitchEntity` extends `CoordinatorEntity` and `SwitchEntity`
 - Device class: OUTLET
-- State from `coordinator.data.is_on` with optimistic updates (`_attr_is_on_next`)
+- State from `coordinator.data.is_on`, with an optimistic `_optimistic_is_on` override that the `is_on` property prefers until the next genuine measurement clears it (gated on `coordinator.measurement_count`)
 - Commands sent via `coordinator.async_send_switch_command()`
 - Triggers coordinator refresh after switch commands
 
@@ -153,18 +155,17 @@ All three checks must pass before code can be merged.
 ## Key Implementation Notes
 
 ### BLE Connection Management
-- Connection established in `__init__.py:async_setup_entry()` using `establish_connection()`
-- Connection owned by coordinator, not individual entities
-- Coordinator lifecycle:
-  - `async_setup()`: Start notifications on NOTIFY_UUID
-  - `async_shutdown()`: Stop notifications and disconnect client
-  - Called from `__init__.py` setup/unload
+- Connection fully owned by the coordinator; `__init__.py` only resolves the `BLEDevice` and constructs the coordinator
+- `_async_ensure_connected()` is the single owner of connect + `start_notify`, called at the start of `_async_update_data()` and `async_send_switch_command()`, serialized by `_connect_lock`; it looks up the device by the address and resets the missed-update counter on every successful connect
+- The first connection happens via `async_config_entry_first_refresh()`, which surfaces failures as `ConfigEntryNotReady`
+- `async_shutdown()`: calls `super().async_shutdown()` (cancels the scheduled refresh), then stops notifications and disconnects (guarded, tolerates an already-disconnected client)
+- All GATT writes/`stop_notify` are serialized by `_operation_lock` so a user switch command cannot overlap a poll's MEASURE write
 
 ### State Synchronization and Polling
-- Device polled every 5 seconds via coordinator's `_async_update_data()`
-- Coordinator sends MEASURE command asynchronously
-- Notification handler processes responses and updates all entities via `async_set_updated_data()`
+- Device polled every 5 seconds via coordinator's `_async_update_data()`, which writes MEASURE and awaits the response notification up to `MEASURE_TIMEOUT`
+- Notification handler processes responses and updates all entities via `async_set_updated_data()`; it also resets the missed-update counter and increments `measurement_count`
 - Handles both solicited (from polling) and unsolicited notifications (manual switch press)
+- A single timed-out cycle returns the last-known data; `MAX_MISSED_UPDATES` consecutive misses (or never having received any data) raise `UpdateFailed`
 
 ### Notification Handling
 - Single persistent notification handler in coordinator

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ The device supports additional features (commands), which I don't plan to suppor
 - Get/set device name
 - Set the power limit (called Power Protection in the app)
 - Power consumption history (Home Assistant will already collect power consumption data by itself)
-- Password protection
 - Calibration
 - Firmware update
 
@@ -83,8 +82,22 @@ If the device is found, it will appear in the integration list under **Devices &
 3. Click **+ Add Integration**
 4. Search for "Voltcraft SEM6000 / SPB012BLE"
 5. Select your device from the list of discovered Bluetooth devices
-6. Confirm the device selection
+6. Confirm the device selection. If your device requires a PIN, enter the 4-digit PIN here; otherwise leave it blank
 7. The integration will create a switch entity for your power plug
+
+### PIN / Authentication
+
+Some hardware/firmware versions require a 4-digit PIN before the plug accepts commands. PIN support is optional:
+
+- **Set the PIN at setup** in the confirmation step (leave blank if your device doesn't use one).
+- **Add, change, or remove the PIN later** via the integration's **Reconfigure** option (Settings → Devices & Services → the integration → Configure). Leave the field blank to clear the PIN.
+
+Behavior depends on the device firmware:
+
+- On firmware that **reports** a wrong PIN, the integration shows a re-authentication prompt and **pauses polling** until you re-enter the correct PIN (or fix it via Reconfigure). It does not silently self-heal.
+- On firmware that **silently ignores** a bad login, there is **no** re-authentication prompt — the device simply shows as *unavailable* and the (mains-powered) integration keeps retrying every few seconds until the PIN is corrected or cleared.
+
+If a reachable device is stuck *unavailable* with no re-authentication prompt, the cause may be a required-but-unset PIN, a wrong PIN on silently-ignoring firmware, or a device that doesn't use PIN login — so **set, verify, or clear the PIN via Reconfigure**. The logs show a one-time PIN-timeout warning to help diagnose.
 
 ## Entities
 

--- a/custom_components/voltcraft_sem6000_spb012ble/__init__.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/__init__.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
 
-from bleak import BleakClient
-from bleak_retry_connector import establish_connection
-
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_MAC, Platform
@@ -17,34 +14,17 @@ PLATFORMS: list[Platform] = [Platform.SENSOR, Platform.SWITCH]
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     mac_address = entry.data[CONF_MAC]
-    ble_device = bluetooth.async_ble_device_from_address(hass, mac_address)
+    ble_device = bluetooth.async_ble_device_from_address(hass, mac_address, connectable=True)
     if not ble_device:
         raise ConfigEntryNotReady(f"Device {mac_address} not found")
 
-    client = await establish_connection(
-        BleakClient,
-        ble_device,
-        entry.entry_id,
-    )
+    coord = VoltcraftDataUpdateCoordinator(hass, mac_address, ble_device)
 
-    coord = VoltcraftDataUpdateCoordinator(
-        hass,
-        client,
-        mac_address,
-        ble_device.name,
-    )
-
-    # Setup coordinator (start notifications)
-    await coord.async_setup()
-
-    # Perform initial data fetch
     await coord.async_config_entry_first_refresh()
 
-    # Store coordinator in hass.data
     hass.data.setdefault(DOMAIN, {})
     hass.data[DOMAIN][entry.entry_id] = coord
 
-    # Forward to platforms
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
     return True

--- a/custom_components/voltcraft_sem6000_spb012ble/__init__.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/__init__.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from homeassistant.components import bluetooth
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import CONF_MAC, Platform
+from homeassistant.const import CONF_MAC, CONF_PIN, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.exceptions import ConfigEntryNotReady
 
@@ -18,7 +18,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if not ble_device:
         raise ConfigEntryNotReady(f"Device {mac_address} not found")
 
-    coord = VoltcraftDataUpdateCoordinator(hass, mac_address, ble_device)
+    coord = VoltcraftDataUpdateCoordinator(hass, entry, mac_address, ble_device, entry.data.get(CONF_PIN))
 
     await coord.async_config_entry_first_refresh()
 

--- a/custom_components/voltcraft_sem6000_spb012ble/config_flow.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/config_flow.py
@@ -65,7 +65,7 @@ class MainConfigFlow(ConfigFlow, domain=DOMAIN):
                 continue
 
             if SERVICE_UUID in discovery_info.service_uuids:
-                self._discovered_devices[address] = f"{discovery_info.name} ({address})"
+                self._discovered_devices[address] = discovery_info.name
 
         if not self._discovered_devices:
             return self.async_abort(reason="no_devices_found")
@@ -74,7 +74,9 @@ class MainConfigFlow(ConfigFlow, domain=DOMAIN):
             step_id="user",
             data_schema=vol.Schema(
                 {
-                    vol.Required(CONF_MAC): vol.In(self._discovered_devices),
+                    vol.Required(CONF_MAC): vol.In(
+                        {address: f"{name} ({address})" for address, name in self._discovered_devices.items()}
+                    ),
                 }
             ),
         )

--- a/custom_components/voltcraft_sem6000_spb012ble/config_flow.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/config_flow.py
@@ -5,16 +5,17 @@ from typing import Any
 
 import voluptuous as vol
 
-from homeassistant.const import CONF_MAC
+from homeassistant.const import CONF_MAC, CONF_PIN
 from homeassistant.helpers.device_registry import format_mac
 from homeassistant.components import onboarding
 from homeassistant.components.bluetooth import (
     BluetoothServiceInfoBleak,
     async_discovered_service_info,
 )
-from homeassistant.config_entries import ConfigFlow, ConfigFlowResult
+from homeassistant.config_entries import SOURCE_REAUTH, ConfigFlow, ConfigFlowResult
 
 from .const import DOMAIN, DEVICE_NAME, SERVICE_UUID
+from .protocol import LoginCommand
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -36,13 +37,22 @@ class MainConfigFlow(ConfigFlow, domain=DOMAIN):
         return await self.async_step_confirm()
 
     async def async_step_confirm(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
-        if user_input is not None or not onboarding.async_is_onboarded(self.hass):
-            return self._create_entry()
+        if user_input is None and not onboarding.async_is_onboarded(self.hass):
+            return self._create_entry(None)
 
-        self._set_confirm_only()
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            pin, error = self._validate_pin(user_input, required=False)
+            if error:
+                errors["base"] = error
+            else:
+                return self._create_entry(pin)
+
         return self.async_show_form(
             step_id="confirm",
+            data_schema=vol.Schema({vol.Optional(CONF_PIN): str}),
             description_placeholders={"name": self._name},
+            errors=errors,
         )
 
     async def async_step_user(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
@@ -81,6 +91,47 @@ class MainConfigFlow(ConfigFlow, domain=DOMAIN):
             ),
         )
 
+    async def async_step_reauth(self, entry_data: dict[str, Any]) -> ConfigFlowResult:
+        return await self.async_step_reauth_confirm()
+
+    async def async_step_reauth_confirm(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            pin, error = self._validate_pin(user_input, required=True)
+            if error:
+                errors["base"] = error
+            else:
+                return self.async_update_reload_and_abort(self._get_reauth_entry(), data_updates={CONF_PIN: pin})
+
+        return self.async_show_form(
+            step_id="reauth_confirm",
+            data_schema=vol.Schema({vol.Required(CONF_PIN): str}),
+            errors=errors,
+        )
+
+    async def async_step_reconfigure(self, user_input: dict[str, Any] | None = None) -> ConfigFlowResult:
+        entry = self._get_reconfigure_entry()
+        errors: dict[str, str] = {}
+        if user_input is not None:
+            pin, error = self._validate_pin(user_input, required=False)
+            if error:
+                errors["base"] = error
+            else:
+                new_data = dict(entry.data)
+                if pin is None:
+                    new_data.pop(CONF_PIN, None)
+                else:
+                    new_data[CONF_PIN] = pin
+                for flow in entry.async_get_active_flows(self.hass, {SOURCE_REAUTH}):
+                    self.hass.config_entries.flow.async_abort(flow["flow_id"])
+                return self.async_update_reload_and_abort(entry, data=new_data)
+
+        current_pin = entry.data.get(CONF_PIN)
+        schema = vol.Schema({vol.Optional(CONF_PIN): str})
+        if current_pin:
+            schema = self.add_suggested_values_to_schema(schema, {CONF_PIN: current_pin})
+        return self.async_show_form(step_id="reconfigure", data_schema=schema, errors=errors)
+
     @property
     def _name(self) -> str:
         return self.context["title_placeholders"]["name"] or DEVICE_NAME
@@ -89,8 +140,19 @@ class MainConfigFlow(ConfigFlow, domain=DOMAIN):
     def _name(self, name: str) -> None:
         self.context["title_placeholders"] = {"name": name}
 
-    def _create_entry(self) -> ConfigFlowResult:
-        return self.async_create_entry(
-            title=self._name,
-            data={CONF_MAC: self._mac_address},
-        )
+    def _create_entry(self, pin: str | None) -> ConfigFlowResult:
+        data: dict[str, Any] = {CONF_MAC: self._mac_address}
+        if pin is not None:
+            data[CONF_PIN] = pin
+        return self.async_create_entry(title=self._name, data=data)
+
+    def _validate_pin(self, user_input: dict[str, Any], *, required: bool) -> tuple[str | None, str | None]:
+        value = user_input.get(CONF_PIN)
+        if not value:
+            return (None, "invalid_pin") if required else (None, None)
+        if not isinstance(value, str):
+            return None, "invalid_pin"
+        try:
+            return LoginCommand.normalize_pin(value), None
+        except ValueError:
+            return None, "invalid_pin"

--- a/custom_components/voltcraft_sem6000_spb012ble/const.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/const.py
@@ -13,4 +13,7 @@ SCAN_INTERVAL = timedelta(seconds=5)
 # Kept below SCAN_INTERVAL so each poll resolves before the next is scheduled.
 MEASURE_TIMEOUT = 4.0
 
+# Must exceed the device's worst-case response to the 0x17 login; a shorter value makes every login time out.
+LOGIN_TIMEOUT = 10.0
+
 MAX_MISSED_UPDATES = 3

--- a/custom_components/voltcraft_sem6000_spb012ble/const.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/const.py
@@ -9,3 +9,8 @@ NOTIFY_UUID = "0000fff4-0000-1000-8000-00805f9b34fb"
 
 # Polling interval for sensor updates
 SCAN_INTERVAL = timedelta(seconds=5)
+
+# Kept below SCAN_INTERVAL so each poll resolves before the next is scheduled.
+MEASURE_TIMEOUT = 4.0
+
+MAX_MISSED_UPDATES = 3

--- a/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
@@ -1,17 +1,29 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from dataclasses import dataclass
 
 from bleak import BleakClient, BleakGATTCharacteristic
+from bleak.backends.device import BLEDevice
 from bleak.exc import BleakError
+from bleak_retry_connector import establish_connection
 
+from homeassistant.components import bluetooth
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo
-from homeassistant.helpers.device_registry import format_mac
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo, format_mac
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
-from .const import COMMAND_UUID, DEVICE_NAME, DOMAIN, NOTIFY_UUID, SCAN_INTERVAL
+from .const import (
+    COMMAND_UUID,
+    DEVICE_NAME,
+    DOMAIN,
+    MAX_MISSED_UPDATES,
+    MEASURE_TIMEOUT,
+    NOTIFY_UUID,
+    SCAN_INTERVAL,
+)
 from .protocol import (
     Command,
     MeasureNotifyPayload,
@@ -64,9 +76,8 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
     def __init__(
         self,
         hass: HomeAssistant,
-        client: BleakClient,
         mac: str,
-        device_name: str | None,
+        ble_device: BLEDevice,
     ) -> None:
         super().__init__(
             hass,
@@ -74,10 +85,15 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
             name=f"{DOMAIN}_{mac}",
             update_interval=SCAN_INTERVAL,
         )
-        self.client = client
+        self._mac_address = mac
         self.mac = format_mac(mac)
-        self._device_name = device_name
-        self._latest_data: VoltcraftData | None = None
+        self._device_name = ble_device.name
+        self.client: BleakClient | None = None
+        self._connect_lock = asyncio.Lock()
+        self._operation_lock = asyncio.Lock()
+        self._measure_cond = asyncio.Condition()
+        self._missed_updates = 0
+        self.measurement_count = 0
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -87,33 +103,28 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
             name=self._device_name or DEVICE_NAME,
         )
 
-    async def async_setup(self) -> None:
-        await self.client.start_notify(NOTIFY_UUID, self._handle_notify)
-
-    async def async_shutdown(self) -> None:
-        try:
-            await self.client.stop_notify(NOTIFY_UUID)
-        except BleakError as err:
-            _LOGGER.debug("Error stopping notifications: %s", err)
-
-        try:
-            await self.client.disconnect()
-        except BleakError as err:
-            _LOGGER.debug("Error disconnecting client: %s", err)
-
     async def _async_update_data(self) -> VoltcraftData | None:
-        """Fetch data from the device.
+        """Send a measure command and return the response.
 
-        This sends a measure command and returns the latest data.
-        The actual data update happens asynchronously via a notification handler.
+        Awaits the notification triggered by the command so that a device which
+        stops responding is detected and entities are marked unavailable.
         """
+        client = await self._async_ensure_connected()
+        start_count = self.measurement_count
 
         try:
-            await self.client.write_gatt_char(COMMAND_UUID, Command.MEASURE.build_payload())
-        except BleakError as err:
-            raise UpdateFailed(f"Failed to send measure command: {err}") from err
+            async with asyncio.timeout(MEASURE_TIMEOUT):
+                async with self._operation_lock:
+                    await client.write_gatt_char(COMMAND_UUID, Command.MEASURE.build_payload())
+                async with self._measure_cond:
+                    await self._measure_cond.wait_for(lambda: self.measurement_count != start_count)
+        except (TimeoutError, BleakError) as err:
+            self._missed_updates += 1
+            if self.data is None or self._missed_updates >= MAX_MISSED_UPDATES:
+                await self._async_teardown()
+                raise UpdateFailed(f"No measurement received: {err}") from err
 
-        return self._latest_data
+        return self.data
 
     async def _handle_notify(self, sender: BleakGATTCharacteristic, data: bytearray) -> None:
         """Handle notifications from the device."""
@@ -122,20 +133,83 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
 
         match payload:
             case MeasureNotifyPayload():
-                self._latest_data = VoltcraftData.from_payload(payload)
-                self.async_set_updated_data(self._latest_data)
+                self._missed_updates = 0
+                self.measurement_count += 1
+                self.async_set_updated_data(VoltcraftData.from_payload(payload))
+                async with self._measure_cond:
+                    self._measure_cond.notify_all()
 
             case SwitchNotifyPayload():
                 # Switch state changed, trigger immediate measure to update data
-                self.hass.create_task(self.async_request_refresh())
+                self.hass.async_create_task(self.async_request_refresh())
 
             case None:
                 _LOGGER.warning("Unknown payload received: %s", data.hex())
 
+    async def async_shutdown(self) -> None:
+        await super().async_shutdown()
+
+        if self.client is None:
+            return
+
+        try:
+            await self.client.stop_notify(NOTIFY_UUID)
+        except BleakError as err:
+            _LOGGER.debug("Error stopping notifications: %s", err)
+
+        await self._async_safe_disconnect(self.client, "shutdown")
+
     async def async_send_switch_command(self, mode: SwitchModes) -> None:
         """Send a switch command to the device."""
         try:
-            await self.client.write_gatt_char(COMMAND_UUID, mode.build_payload())
-        except BleakError as err:
+            client = await self._async_ensure_connected()
+            async with asyncio.timeout(MEASURE_TIMEOUT):
+                async with self._operation_lock:
+                    await client.write_gatt_char(COMMAND_UUID, mode.build_payload())
+        except (TimeoutError, BleakError, UpdateFailed) as err:
             _LOGGER.error("Failed to send switch command: %s", err)
-            raise
+            raise HomeAssistantError(f"Failed to send switch command: {err}") from err
+
+    async def _async_teardown(self) -> None:
+        """Drop the connection so the next update re-establishes a fresh one."""
+        client = self.client
+        if client is None:
+            return
+        await self._async_safe_disconnect(client, "teardown")
+        # A concurrent reconnect may have replaced the client during the await;
+        # only clear the field if it still points at the one we tore down.
+        if self.client is client:
+            self.client = None
+
+    async def _async_ensure_connected(self) -> BleakClient:
+        if self.client is not None and self.client.is_connected:
+            return self.client
+
+        async with self._connect_lock:
+            if self.client is not None and self.client.is_connected:
+                return self.client
+
+            ble_device = bluetooth.async_ble_device_from_address(self.hass, self._mac_address, connectable=True)
+            if ble_device is None:
+                raise UpdateFailed(f"Device {self._mac_address} not found")
+
+            client: BleakClient | None = None
+            try:
+                client = await establish_connection(BleakClient, ble_device, self.name)
+                # start_notify has no internal timeout and can hang
+                async with asyncio.timeout(MEASURE_TIMEOUT):
+                    await client.start_notify(NOTIFY_UUID, self._handle_notify)
+            except (TimeoutError, BleakError) as err:
+                if client is not None:
+                    await self._async_safe_disconnect(client, "after failed connect")
+                raise UpdateFailed(f"Failed to connect to {self._mac_address}: {err}") from err
+
+            self.client = client
+            self._missed_updates = 0
+            return client
+
+    async def _async_safe_disconnect(self, client: BleakClient, context: str) -> None:
+        try:
+            await client.disconnect()
+        except BleakError as err:
+            _LOGGER.debug("Error disconnecting client (%s): %s", context, err)

--- a/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/coordinator.py
@@ -10,8 +10,9 @@ from bleak.exc import BleakError
 from bleak_retry_connector import establish_connection
 
 from homeassistant.components import bluetooth
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.device_registry import CONNECTION_BLUETOOTH, DeviceInfo, format_mac
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator, UpdateFailed
 
@@ -19,6 +20,7 @@ from .const import (
     COMMAND_UUID,
     DEVICE_NAME,
     DOMAIN,
+    LOGIN_TIMEOUT,
     MAX_MISSED_UPDATES,
     MEASURE_TIMEOUT,
     NOTIFY_UUID,
@@ -26,10 +28,12 @@ from .const import (
 )
 from .protocol import (
     Command,
+    LoginNotifyPayload,
     MeasureNotifyPayload,
     NotifyPayload,
     SwitchModes,
     SwitchNotifyPayload,
+    LoginCommand,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -76,22 +80,30 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
     def __init__(
         self,
         hass: HomeAssistant,
+        config_entry: ConfigEntry,
         mac: str,
         ble_device: BLEDevice,
+        pin: str | None,
     ) -> None:
         super().__init__(
             hass,
             _LOGGER,
+            config_entry=config_entry,
             name=f"{DOMAIN}_{mac}",
             update_interval=SCAN_INTERVAL,
         )
         self._mac_address = mac
         self.mac = format_mac(mac)
         self._device_name = ble_device.name
+        self._pin = pin
         self.client: BleakClient | None = None
         self._connect_lock = asyncio.Lock()
         self._operation_lock = asyncio.Lock()
         self._measure_cond = asyncio.Condition()
+        self._login_cond = asyncio.Condition()
+        self._login_count = 0
+        self._login_result: bool | None = None
+        self._login_warning_logged = False
         self._missed_updates = 0
         self.measurement_count = 0
 
@@ -143,6 +155,12 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
                 # Switch state changed, trigger immediate measure to update data
                 self.hass.async_create_task(self.async_request_refresh())
 
+            case LoginNotifyPayload():
+                async with self._login_cond:
+                    self._login_result = payload.was_successful
+                    self._login_count += 1
+                    self._login_cond.notify_all()
+
             case None:
                 _LOGGER.warning("Unknown payload received: %s", data.hex())
 
@@ -158,6 +176,7 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
             _LOGGER.debug("Error stopping notifications: %s", err)
 
         await self._async_safe_disconnect(self.client, "shutdown")
+        self.client = None
 
     async def async_send_switch_command(self, mode: SwitchModes) -> None:
         """Send a switch command to the device."""
@@ -166,7 +185,7 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
             async with asyncio.timeout(MEASURE_TIMEOUT):
                 async with self._operation_lock:
                     await client.write_gatt_char(COMMAND_UUID, mode.build_payload())
-        except (TimeoutError, BleakError, UpdateFailed) as err:
+        except (TimeoutError, BleakError, UpdateFailed, ConfigEntryAuthFailed) as err:
             _LOGGER.error("Failed to send switch command: %s", err)
             raise HomeAssistantError(f"Failed to send switch command: {err}") from err
 
@@ -199,14 +218,50 @@ class VoltcraftDataUpdateCoordinator(DataUpdateCoordinator[VoltcraftData | None]
                 # start_notify has no internal timeout and can hang
                 async with asyncio.timeout(MEASURE_TIMEOUT):
                     await client.start_notify(NOTIFY_UUID, self._handle_notify)
+                await self._async_login(client)
             except (TimeoutError, BleakError) as err:
                 if client is not None:
                     await self._async_safe_disconnect(client, "after failed connect")
                 raise UpdateFailed(f"Failed to connect to {self._mac_address}: {err}") from err
+            except ConfigEntryAuthFailed:
+                if client is not None:
+                    await self._async_safe_disconnect(client, "after failed login")
+                raise
 
             self.client = client
             self._missed_updates = 0
             return client
+
+    async def _async_login(self, client: BleakClient) -> None:
+        """Authenticate the session when a PIN is configured (firmware that requires it)."""
+        if self._pin is None:
+            return
+
+        try:
+            payload = LoginCommand.build_payload(self._pin)
+        except ValueError as err:
+            raise ConfigEntryAuthFailed("Invalid stored PIN") from err
+
+        start = self._login_count
+        try:
+            async with asyncio.timeout(LOGIN_TIMEOUT):
+                async with self._operation_lock:
+                    await client.write_gatt_char(COMMAND_UUID, payload)
+                async with self._login_cond:
+                    await self._login_cond.wait_for(lambda: self._login_count != start)
+                    success = self._login_result
+        except TimeoutError:
+            if not self._login_warning_logged:
+                _LOGGER.warning(
+                    "Login to %s timed out; the configured PIN may be wrong or the device may not use a PIN",
+                    self._mac_address,
+                )
+                self._login_warning_logged = True
+            raise
+
+        if not success:
+            raise ConfigEntryAuthFailed("Invalid PIN")
+        self._login_warning_logged = False
 
     async def _async_safe_disconnect(self, client: BleakClient, context: str) -> None:
         try:

--- a/custom_components/voltcraft_sem6000_spb012ble/manifest.json
+++ b/custom_components/voltcraft_sem6000_spb012ble/manifest.json
@@ -15,7 +15,7 @@
     ],
     "documentation": "https://github.com/Anty0/homeassistant-voltcraft_sem6000_spb012ble-integration",
     "integration_type": "device",
-    "iot_class": "local_push",
+    "iot_class": "local_polling",
     "issue_tracker": "https://github.com/Anty0/homeassistant-voltcraft_sem6000_spb012ble-integration/issues",
     "requirements": [
         "bleak-retry-connector"

--- a/custom_components/voltcraft_sem6000_spb012ble/protocol.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/protocol.py
@@ -22,6 +22,15 @@ MEASURE notification layout:
   Bytes 10+    : consumed_energy (big-endian, Wh)
                  14-byte payload (hw v2): 4 bytes
                  12-byte payload (hw v3): 2 bytes
+
+LOGIN (command 0x17): authenticates a session before MEASURE/SWITCH on firmware that
+requires a PIN. The 4-digit PIN is encoded digit-by-digit, one byte per decimal digit
+(e.g. "1234" -> 01 02 03 04). Request body params (after the 0x00 separator) are
+[0x00] + 4 pin bytes + [0x00, 0x00, 0x00, 0x00]; PIN 0000 yields the full request frame
+0f0c170000000000000000000018ffff.
+LOGIN response (10 bytes): success 0f 06 17 00 00 00 00 18 ff ff, failure
+0f 06 17 00 01 00 00 18 ff ff. The status byte is the first argument (data[0] after the
+command/separator split): 0 = success, non-zero = failure.
 """
 
 from __future__ import annotations
@@ -33,6 +42,7 @@ from enum import IntEnum
 class Command(IntEnum):
     SWITCH = 0x03
     MEASURE = 0x04
+    LOGIN = 0x17
 
     def build_payload(self, params: bytearray | None = None) -> bytearray:
         if params is None:
@@ -49,6 +59,24 @@ class SwitchModes(IntEnum):
 
     def build_payload(self) -> bytearray:
         return Command.SWITCH.build_payload(bytearray([self]))
+
+
+class LoginCommand:
+    PIN_LENGTH = 4
+
+    @staticmethod
+    def build_payload(pin: str) -> bytearray:
+        pin = LoginCommand.normalize_pin(pin)
+        pin_bytes = bytearray(int(digit) for digit in pin)
+        params = bytearray([0x00]) + pin_bytes + bytearray(4)
+        return Command.LOGIN.build_payload(params)
+
+    @staticmethod
+    def normalize_pin(pin: str) -> str:
+        pin = pin.strip()
+        if len(pin) != LoginCommand.PIN_LENGTH or any(char not in "0123456789" for char in pin):
+            raise ValueError(f"PIN must be exactly {LoginCommand.PIN_LENGTH} digits")
+        return pin
 
 
 class NotifyPayload:
@@ -77,6 +105,8 @@ class NotifyPayload:
             return SwitchNotifyPayload.from_data(arguments)
         elif command == Command.MEASURE:
             return MeasureNotifyPayload.from_data(arguments)
+        elif command == Command.LOGIN:
+            return LoginNotifyPayload.from_data(arguments)
         else:
             # Unknown command
             return None
@@ -117,4 +147,15 @@ class SwitchNotifyPayload(NotifyPayload):
         return SwitchNotifyPayload()
 
 
-ParsedNotifyPayload = SwitchNotifyPayload | MeasureNotifyPayload
+@dataclass(frozen=True)
+class LoginNotifyPayload(NotifyPayload):
+    was_successful: bool
+
+    @staticmethod
+    def from_data(data: bytearray) -> LoginNotifyPayload | None:
+        if len(data) < 1:
+            return None
+        return LoginNotifyPayload(was_successful=data[0] == 0x00)
+
+
+ParsedNotifyPayload = SwitchNotifyPayload | MeasureNotifyPayload | LoginNotifyPayload

--- a/custom_components/voltcraft_sem6000_spb012ble/protocol.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/protocol.py
@@ -54,21 +54,20 @@ class SwitchModes(IntEnum):
 class NotifyPayload:
     @staticmethod
     def from_payload(payload: bytearray) -> ParsedNotifyPayload | None:
-        if payload[0] != 0x0F:
+        if len(payload) < 2 or payload[0] != 0x0F:
             # Not a valid payload
             return None
 
         length = payload[1]
         body = payload[2 : length + 2]
 
+        if length + 2 > len(payload) or len(body) < 3:
+            return None
+
         params = body[0:-1]
 
-        # # The checksum always seems to be wrong...
-        # checksum = body[-1]
-        # checksumExpected = (1 + sum(list(params))) % 256
-        # if checksum != checksumExpected:
-        #     # Not a valid payload
-        #     return None
+        # Checksum validation is disabled: checksums from the device never match
+        # the computed value, so we cannot use them to reject payloads.
 
         command = params[0]
 
@@ -83,6 +82,10 @@ class NotifyPayload:
             return None
 
 
+# Minimum valid MEASURE frame length (see the module docstring layout).
+MEASURE_ARGS_MIN_LEN = 12
+
+
 @dataclass(frozen=True)
 class MeasureNotifyPayload(NotifyPayload):
     is_on: bool
@@ -93,16 +96,17 @@ class MeasureNotifyPayload(NotifyPayload):
     consumed_energy: int
 
     @staticmethod
-    def from_data(data: bytearray) -> MeasureNotifyPayload:
-        # data[8:10] are unknown padding bytes — skip them
-        # consumed_energy starts at offset 10; length varies by hw version
+    def from_data(data: bytearray) -> MeasureNotifyPayload | None:
+        if len(data) < MEASURE_ARGS_MIN_LEN:
+            # Truncated frame
+            return None
         return MeasureNotifyPayload(
             is_on=bool(data[0]),
             power=int.from_bytes(data[1:4], byteorder="big"),
             voltage=int(data[4]),
             current=int.from_bytes(data[5:7], byteorder="big"),
             frequency=int(data[7]),
-            consumed_energy=int.from_bytes(data[10:], byteorder="big"),
+            consumed_energy=int.from_bytes(data[10:14], byteorder="big"),
         )
 
 

--- a/custom_components/voltcraft_sem6000_spb012ble/switch.py
+++ b/custom_components/voltcraft_sem6000_spb012ble/switch.py
@@ -1,19 +1,16 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import DOMAIN
 from .coordinator import VoltcraftDataUpdateCoordinator
 from .protocol import SwitchModes
-
-_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(
@@ -33,13 +30,35 @@ class MainSwitchEntity(CoordinatorEntity[VoltcraftDataUpdateCoordinator], Switch
         self._attr_unique_id = coordinator.mac
         self._attr_name = "Power switch"
         self._attr_device_info = coordinator.device_info
+        self._optimistic_is_on: bool | None = None
+        self._optimistic_count = coordinator.measurement_count
 
     @property
     def is_on(self) -> bool | None:
+        if self._optimistic_is_on is not None:
+            return self._optimistic_is_on
         return self.coordinator.data.is_on if self.coordinator.data else None
 
     async def async_turn_on(self, **kwargs: Any) -> None:
-        await self.coordinator.async_send_switch_command(SwitchModes.ON)
+        await self._async_set_state(True)
 
     async def async_turn_off(self, **kwargs: Any) -> None:
-        await self.coordinator.async_send_switch_command(SwitchModes.OFF)
+        await self._async_set_state(False)
+
+    async def _async_set_state(self, on: bool) -> None:
+        await self.coordinator.async_send_switch_command(SwitchModes.ON if on else SwitchModes.OFF)
+        self._optimistic_is_on = on
+        self._optimistic_count = self.coordinator.measurement_count
+        self.async_write_ha_state()
+        await self.coordinator.async_request_refresh()
+
+    @callback
+    def _handle_coordinator_update(self) -> None:
+        # Clear the optimistic value only once a measurement that could have observed
+        # the toggle arrives: one confirming the requested state, or the second since
+        # the command (the first may be a stale poll already in flight at toggle time).
+        if self._optimistic_is_on is not None and self.coordinator.data is not None:
+            advanced = self.coordinator.measurement_count - self._optimistic_count
+            if self.coordinator.data.is_on == self._optimistic_is_on or advanced >= 2:
+                self._optimistic_is_on = None
+        super()._handle_coordinator_update()

--- a/custom_components/voltcraft_sem6000_spb012ble/translations/en.json
+++ b/custom_components/voltcraft_sem6000_spb012ble/translations/en.json
@@ -2,7 +2,7 @@
     "config": {
         "step": {
             "confirm": {
-                "description": "[%key:common::config_flow::description::confirm_setup%]",
+                "description": "Do you want to start setup?",
                 "data": {
                     "pin": "PIN"
                 },
@@ -35,9 +35,9 @@
             "invalid_pin": "The PIN must be exactly 4 digits."
         },
         "abort": {
-            "no_devices_found": "[%key:common::config_flow::abort::no_devices_found%]",
-            "reauth_successful": "[%key:common::config_flow::abort::reauth_successful%]",
-            "reconfigure_successful": "[%key:common::config_flow::abort::reconfigure_successful%]"
+            "no_devices_found": "No devices found on the network",
+            "reauth_successful": "Re-authentication was successful",
+            "reconfigure_successful": "Re-configuration was successful"
         }
     }
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,7 @@
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+asyncio_mode = "auto"
+
 [tool.ruff]
 line-length = 120
 target-version = "py313"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,18 @@
 ruff~=0.14.6
 mypy~=1.18.2
 
+# Testing
+pytest~=8.3
+pytest-asyncio~=1.0
+pytest-homeassistant-custom-component~=0.13.293
+
+# Transitive Home Assistant component deps; pinned here for CI reproducibility.
+aiousbwatcher~=1.1
+pyserial~=3.5
+dbus-fast~=5.0
+# aiodns==3.5.0 (pinned by homeassistant) is incompatible with pycares 5.x.
+pycares~=4.11
+
 # Runtime dependencies (needed for type checking and IDE)
 homeassistant~=2025.11.3
 bleak~=2.0.0

--- a/tests/ble_harness.py
+++ b/tests/ble_harness.py
@@ -1,0 +1,80 @@
+"""Shared fake-BLE scaffolding for the coordinator and recovery tests.
+
+A small importable helper module (not a test module) so both suites consume the
+same FakeClient and frame builders without coupling to each other's internals.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from bleak.exc import BleakError
+
+RAW_MAC = "AA:BB:CC:DD:EE:FF"
+FORMATTED_MAC = "aa:bb:cc:dd:ee:ff"
+
+MEASURE_ARGS = bytearray([0x01, 0x00, 0x05, 0xDC, 0xE6, 0x00, 0xFA, 0x32, 0xAB, 0xCD, 0x04, 0xD2])
+
+LOGIN_SUCCESS_FRAME = bytearray.fromhex("0f06170000000018ffff")
+LOGIN_FAILURE_FRAME = bytearray.fromhex("0f06170001000018ffff")
+
+
+def measure_frame() -> bytearray:
+    params = bytearray([0x04, 0x00]) + MEASURE_ARGS
+    body = params + bytearray([0x00])
+    return bytearray([0x0F, len(body)]) + body + bytearray([0xFF, 0xFF])
+
+
+def switch_frame() -> bytearray:
+    params = bytearray([0x03, 0x00, 0x01])
+    body = params + bytearray([0x00])
+    return bytearray([0x0F, len(body)]) + body + bytearray([0xFF, 0xFF])
+
+
+def written_commands(client: FakeClient) -> list[int]:
+    return [w[2] for w in client.written]
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.notify_cb = None
+        self.written: list[bytes] = []
+        self.stopped = False
+        self.disconnect_error = False
+        self.raise_on_write = False
+        self.hang_on_write = False
+        self.raise_on_login_write = False
+        self.hang_on_login_write = False
+        self.auto_measure_frame: bytearray | None = None
+        self.auto_login_frame: bytearray | None = None
+
+    async def start_notify(self, uuid, cb) -> None:
+        self.notify_cb = cb
+
+    async def stop_notify(self, uuid) -> None:
+        self.stopped = True
+
+    async def write_gatt_char(self, uuid, data) -> None:
+        cmd = bytes(data)[2]
+        if self.raise_on_write or (self.raise_on_login_write and cmd == 0x17):
+            raise BleakError("write failed")
+        if self.hang_on_write or (self.hang_on_login_write and cmd == 0x17):
+            await asyncio.Event().wait()  # never resolves; relies on the caller's timeout
+        self.written.append(bytes(data))
+        if cmd == 0x17 and self.auto_login_frame is not None:
+            asyncio.get_running_loop().create_task(self._deliver(self.auto_login_frame))
+        if cmd == 0x04 and self.auto_measure_frame is not None:
+            asyncio.get_running_loop().create_task(self._deliver(self.auto_measure_frame))
+
+    async def _deliver(self, frame: bytearray) -> None:
+        if self.notify_cb is not None:
+            await self.notify_cb(None, frame)
+
+    async def deliver_frame(self, frame: bytearray) -> None:
+        await self.notify_cb(None, frame)
+
+    async def disconnect(self) -> None:
+        if self.disconnect_error:
+            raise BleakError("disconnect failed")
+        self.is_connected = False

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,7 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations(enable_custom_integrations):
+    """Enable loading the custom integration in all tests that set up HA."""
+    yield

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,11 +1,14 @@
-"""Tests for the config flow entry title and picker label."""
+"""Tests for the config flow: device picker, optional PIN, reauth and reconfigure."""
 
 from __future__ import annotations
 
 from types import SimpleNamespace
 from unittest.mock import patch
 
-from homeassistant.const import CONF_MAC
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.const import CONF_MAC, CONF_PIN
 from homeassistant.data_entry_flow import FlowResultType
 
 from custom_components.voltcraft_sem6000_spb012ble import config_flow
@@ -13,6 +16,15 @@ from custom_components.voltcraft_sem6000_spb012ble.const import DOMAIN, SERVICE_
 
 ADDRESS = "AA:BB:CC:DD:EE:FF"
 NAME = "Test Plug"
+
+
+async def _reach_confirm(hass, monkeypatch):
+    """Drive the user step up to the confirmation form (onboarded path)."""
+    discovery = SimpleNamespace(address=ADDRESS, name=NAME, service_uuids=[SERVICE_UUID])
+    monkeypatch.setattr(config_flow, "async_discovered_service_info", lambda hass: [discovery])
+    monkeypatch.setattr(config_flow.onboarding, "async_is_onboarded", lambda hass: True)
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    return await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_MAC: ADDRESS})
 
 
 async def test_user_flow_title_is_bare_name(hass, monkeypatch):
@@ -43,3 +55,150 @@ async def test_user_flow_aborts_when_no_devices(hass, monkeypatch):
     result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
     assert result["type"] == FlowResultType.ABORT
     assert result["reason"] == "no_devices_found"
+
+
+async def test_confirm_stores_optional_pin(hass, monkeypatch):
+    result = await _reach_confirm(hass, monkeypatch)
+    assert result["type"] == FlowResultType.FORM
+    with patch.object(hass.config_entries, "async_setup", return_value=True):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "1234"})
+        await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_MAC: ADDRESS, CONF_PIN: "1234"}
+
+
+async def test_confirm_empty_pin_stores_none(hass, monkeypatch):
+    result = await _reach_confirm(hass, monkeypatch)
+    with patch.object(hass.config_entries, "async_setup", return_value=True):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert CONF_PIN not in result["data"]
+
+
+async def test_confirm_invalid_pin_shows_error(hass, monkeypatch):
+    result = await _reach_confirm(hass, monkeypatch)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "12"})
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_pin"}
+
+
+async def test_confirm_leading_zero_pin_preserved(hass, monkeypatch):
+    result = await _reach_confirm(hass, monkeypatch)
+    with patch.object(hass.config_entries, "async_setup", return_value=True):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "0007"})
+        await hass.async_block_till_done()
+    assert result["data"][CONF_PIN] == "0007"
+
+
+async def test_non_onboarded_auto_creates_without_pin(hass, monkeypatch):
+    # Calling the step directly returns the CREATE_ENTRY result without the flow
+    # manager setting up the entry (which would pull in the bluetooth scanner).
+    monkeypatch.setattr(config_flow.onboarding, "async_is_onboarded", lambda hass: False)
+    flow = config_flow.MainConfigFlow()
+    flow.hass = hass
+    flow.context = {"title_placeholders": {"name": NAME}}
+    flow._mac_address = ADDRESS
+    result = await flow.async_step_confirm()  # user_input None, not onboarded -> create directly
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"] == {CONF_MAC: ADDRESS}
+
+
+def test_validate_pin_unit():
+    flow = config_flow.MainConfigFlow()
+    assert flow._validate_pin({}, required=False) == (None, None)
+    assert flow._validate_pin({}, required=True) == (None, "invalid_pin")
+    assert flow._validate_pin({CONF_PIN: ""}, required=False) == (None, None)
+    assert flow._validate_pin({CONF_PIN: "    "}, required=False) == (None, "invalid_pin")
+    assert flow._validate_pin({CONF_PIN: 1234}, required=False) == (None, "invalid_pin")
+    assert flow._validate_pin({CONF_PIN: 1234}, required=True) == (None, "invalid_pin")
+    assert flow._validate_pin({CONF_PIN: "1234"}, required=False) == ("1234", None)
+
+
+def _entry(hass, data):
+    entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id="aa:bb:cc:dd:ee:ff")
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def test_reauth_updates_pin(hass, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    monkeypatch.setattr(hass.config_entries, "async_schedule_reload", lambda entry_id: None)
+
+    result = await entry.start_reauth_flow(hass)
+    assert result["type"] == FlowResultType.FORM
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "1234"})
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data == {CONF_MAC: ADDRESS, CONF_PIN: "1234"}
+
+
+async def test_reauth_rejects_invalid_pin(hass, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    monkeypatch.setattr(hass.config_entries, "async_schedule_reload", lambda entry_id: None)
+
+    result = await entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "12"})
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_pin"}
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "1234"})
+    assert result["type"] == FlowResultType.ABORT
+
+
+async def test_reconfigure_updates_pin_keeps_mac(hass, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    monkeypatch.setattr(hass.config_entries, "async_schedule_reload", lambda entry_id: None)
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "4321"})
+    assert result["type"] == FlowResultType.ABORT
+    assert entry.data == {CONF_MAC: ADDRESS, CONF_PIN: "4321"}
+
+
+async def test_reconfigure_clears_pin(hass, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    monkeypatch.setattr(hass.config_entries, "async_schedule_reload", lambda entry_id: None)
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == FlowResultType.ABORT
+    assert entry.data == {CONF_MAC: ADDRESS}
+
+
+async def test_reconfigure_adds_pin_to_entry_without_one(hass, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS})
+    monkeypatch.setattr(hass.config_entries, "async_schedule_reload", lambda entry_id: None)
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "5678"})
+    assert result["type"] == FlowResultType.ABORT
+    assert entry.data == {CONF_MAC: ADDRESS, CONF_PIN: "5678"}
+
+
+async def test_reconfigure_invalid_pin_shows_error(hass, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "99"})
+    assert result["type"] == FlowResultType.FORM
+    assert result["errors"] == {"base": "invalid_pin"}
+
+
+async def test_reconfigure_prefills_current_pin(hass, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    result = await entry.start_reconfigure_flow(hass)
+    assert result["type"] == FlowResultType.FORM
+    marker = next(key for key in result["data_schema"].schema if key == CONF_PIN)
+    assert marker.description == {"suggested_value": "0000"}
+
+
+async def test_reconfigure_dismisses_pending_reauth(hass, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    monkeypatch.setattr(hass.config_entries, "async_schedule_reload", lambda entry_id: None)
+
+    await entry.start_reauth_flow(hass)
+    assert any(f["context"]["source"] == SOURCE_REAUTH for f in hass.config_entries.flow.async_progress())
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "1234"})
+    assert result["type"] == FlowResultType.ABORT
+    assert not any(f["context"]["source"] == SOURCE_REAUTH for f in hass.config_entries.flow.async_progress())

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,45 @@
+"""Tests for the config flow entry title and picker label."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from homeassistant.const import CONF_MAC
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.voltcraft_sem6000_spb012ble import config_flow
+from custom_components.voltcraft_sem6000_spb012ble.const import DOMAIN, SERVICE_UUID
+
+ADDRESS = "AA:BB:CC:DD:EE:FF"
+NAME = "Test Plug"
+
+
+async def test_user_flow_title_is_bare_name(hass, monkeypatch):
+    discovery = SimpleNamespace(address=ADDRESS, name=NAME, service_uuids=[SERVICE_UUID])
+    monkeypatch.setattr(config_flow, "async_discovered_service_info", lambda hass: [discovery])
+
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    assert result["type"] == FlowResultType.FORM
+
+    # The picker keeps the address so identically-named plugs stay distinguishable.
+    container = result["data_schema"].schema[CONF_MAC].container
+    assert any(ADDRESS in label for label in container.values())
+
+    # Stub entry setup so finishing the flow does not pull in the bluetooth
+    # dependency (which needs a real adapter); the test only checks flow output.
+    with patch.object(hass.config_entries, "async_setup", return_value=True):
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_MAC: ADDRESS})
+        if result["type"] == FlowResultType.FORM:
+            result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+        await hass.async_block_till_done()
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == NAME
+
+
+async def test_user_flow_aborts_when_no_devices(hass, monkeypatch):
+    monkeypatch.setattr(config_flow, "async_discovered_service_info", lambda hass: [])
+    result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": "user"})
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "no_devices_found"

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,89 +1,62 @@
-"""Tests for the coordinator's update/timeout/reconnect state machine.
+"""Tests for the coordinator's update/timeout/reconnect/login state machine.
 
 Driven with a fake BleakClient and the Home Assistant test harness. The
-module-level MEASURE_TIMEOUT is patched small so timed-out cycles are fast.
+module-level MEASURE_TIMEOUT / LOGIN_TIMEOUT are patched small so timed-out cycles
+are fast.
 """
 
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import dataclass
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from bleak.exc import BleakError
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.exceptions import HomeAssistantError
+from homeassistant.config_entries import SOURCE_REAUTH
+from homeassistant.const import CONF_MAC
+from homeassistant.exceptions import ConfigEntryAuthFailed, HomeAssistantError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.voltcraft_sem6000_spb012ble import coordinator as coord_mod
+from custom_components.voltcraft_sem6000_spb012ble.const import DOMAIN
 from custom_components.voltcraft_sem6000_spb012ble.coordinator import (
     VoltcraftData,
     VoltcraftDataUpdateCoordinator,
 )
-from custom_components.voltcraft_sem6000_spb012ble.protocol import MeasureNotifyPayload
-
-RAW_MAC = "AA:BB:CC:DD:EE:FF"
-FORMATTED_MAC = "aa:bb:cc:dd:ee:ff"
-
-MEASURE_ARGS = bytearray([0x01, 0x00, 0x05, 0xDC, 0xE6, 0x00, 0xFA, 0x32, 0xAB, 0xCD, 0x04, 0xD2])
-
-
-def measure_frame() -> bytearray:
-    params = bytearray([0x04, 0x00]) + MEASURE_ARGS
-    body = params + bytearray([0x00])
-    return bytearray([0x0F, len(body)]) + body + bytearray([0xFF, 0xFF])
-
-
-def switch_frame() -> bytearray:
-    params = bytearray([0x03, 0x00, 0x01])
-    body = params + bytearray([0x00])
-    return bytearray([0x0F, len(body)]) + body + bytearray([0xFF, 0xFF])
+from custom_components.voltcraft_sem6000_spb012ble.protocol import (
+    MeasureNotifyPayload,
+    LoginCommand,
+)
+from tests.ble_harness import (
+    FORMATTED_MAC,
+    LOGIN_FAILURE_FRAME,
+    LOGIN_SUCCESS_FRAME,
+    RAW_MAC,
+    FakeClient,
+    measure_frame,
+    switch_frame,
+    written_commands,
+)
 
 
-class FakeClient:
-    def __init__(self) -> None:
-        self.is_connected = True
-        self.notify_cb = None
-        self.written: list[bytes] = []
-        self.stopped = False
-        self.disconnect_error = False
-        self.raise_on_write = False
-        self.hang_on_write = False
-        self.auto_measure_frame: bytearray | None = None
-
-    async def start_notify(self, uuid, cb) -> None:
-        self.notify_cb = cb
-
-    async def stop_notify(self, uuid) -> None:
-        self.stopped = True
-
-    async def write_gatt_char(self, uuid, data) -> None:
-        if self.raise_on_write:
-            raise BleakError("write failed")
-        if self.hang_on_write:
-            await asyncio.Event().wait()  # never resolves; relies on the caller's timeout
-        self.written.append(bytes(data))
-        if self.auto_measure_frame is not None and bytes(data)[2] == 0x04:
-            asyncio.get_running_loop().create_task(self._deliver(self.auto_measure_frame))
-
-    async def _deliver(self, frame: bytearray) -> None:
-        if self.notify_cb is not None:
-            await self.notify_cb(None, frame)
-
-    async def deliver_measure(self, frame: bytearray) -> None:
-        await self.notify_cb(None, frame)
-
-    async def disconnect(self) -> None:
-        if self.disconnect_error:
-            raise BleakError("disconnect failed")
-        self.is_connected = False
+def reauth_flows(hass, entry) -> list:
+    return [
+        flow
+        for flow in hass.config_entries.flow.async_progress()
+        if flow["context"].get("source") == SOURCE_REAUTH and flow["context"].get("entry_id") == entry.entry_id
+    ]
 
 
 @dataclass
 class Env:
     coord: VoltcraftDataUpdateCoordinator
+    entry: MockConfigEntry
+    ble_device: SimpleNamespace
     establish_mock: AsyncMock
     lookup_mock: MagicMock
     clients: list[FakeClient]
@@ -93,11 +66,12 @@ class Env:
 def env(hass, monkeypatch):
     ble_device = SimpleNamespace(name="Test Plug", address=RAW_MAC)
     clients: list[FakeClient] = []
-    state = {"default_frame": None}
+    state = {"default_frame": None, "default_login_frame": None}
 
     def _establish(*args, **kwargs):
         client = FakeClient()
         client.auto_measure_frame = state["default_frame"]
+        client.auto_login_frame = state["default_login_frame"]
         clients.append(client)
         return client
 
@@ -105,17 +79,29 @@ def env(hass, monkeypatch):
     lookup_mock = MagicMock(return_value=ble_device)
 
     monkeypatch.setattr(coord_mod, "MEASURE_TIMEOUT", 0.1)
+    monkeypatch.setattr(coord_mod, "LOGIN_TIMEOUT", 0.1)
     monkeypatch.setattr(coord_mod, "establish_connection", establish_mock)
     monkeypatch.setattr(coord_mod.bluetooth, "async_ble_device_from_address", lookup_mock)
 
-    coord = VoltcraftDataUpdateCoordinator(hass, RAW_MAC, ble_device)
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: RAW_MAC}, unique_id=FORMATTED_MAC)
+    entry.add_to_hass(hass)
 
-    holder = Env(coord, establish_mock, lookup_mock, clients)
+    coord = VoltcraftDataUpdateCoordinator(hass, entry, RAW_MAC, ble_device, None)
+
+    holder = Env(coord, entry, ble_device, establish_mock, lookup_mock, clients)
 
     def _set_default(frame):
         state["default_frame"] = frame
 
+    def _set_default_login(frame):
+        state["default_login_frame"] = frame
+
+    def _build_coord(pin):
+        return VoltcraftDataUpdateCoordinator(hass, entry, RAW_MAC, ble_device, pin)
+
     holder._set_default = _set_default  # type: ignore[attr-defined]
+    holder._set_default_login = _set_default_login  # type: ignore[attr-defined]
+    holder.build_coord = _build_coord  # type: ignore[attr-defined]
     return holder
 
 
@@ -412,7 +398,16 @@ async def test_async_shutdown_disconnects(env):
     client = env.coord.client
     await env.coord.async_shutdown()
     assert client.stopped is True
-    assert env.coord.client.is_connected is False
+    assert client.is_connected is False
+    assert env.coord.client is None
+
+
+async def test_async_shutdown_is_idempotent(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    await env.coord.async_shutdown()
+    await env.coord.async_shutdown()  # second call early-returns at the None guard, no raise
+    assert env.coord.client is None
 
 
 async def test_switch_notification_triggers_refresh(env):
@@ -464,6 +459,330 @@ async def test_operation_lock_released_before_measure_await(env, monkeypatch):
     await asyncio.wait_for(env.coord._operation_lock.acquire(), 0.1)
     env.coord._operation_lock.release()
 
-    await env.clients[-1].deliver_measure(measure_frame())
+    await env.clients[-1].deliver_frame(measure_frame())
     data = await update_task
     assert isinstance(data, VoltcraftData)
+
+
+# --- PIN / login ---------------------------------------------------------------------------------
+
+
+async def test_no_pin_sends_no_login(env):
+    env._set_default(measure_frame())
+    data = await env.coord._async_update_data()  # coord built with pin=None
+    assert isinstance(data, VoltcraftData)
+    assert all(w[2] != 0x17 for w in env.clients[-1].written)
+
+
+async def test_pin_login_success_then_measure(env):
+    coord = env.build_coord("1234")
+    env._set_default(measure_frame())
+    env._set_default_login(LOGIN_SUCCESS_FRAME)
+    data = await coord._async_update_data()
+
+    client = env.clients[-1]
+    assert client.written[0] == bytes(LoginCommand.build_payload("1234"))
+    assert written_commands(client).index(0x17) < written_commands(client).index(0x04)  # login before measure
+    assert isinstance(data, VoltcraftData)
+    assert coord.measurement_count == 1
+
+
+async def test_login_sent_once_per_live_connection(env):
+    coord = env.build_coord("1234")
+    env._set_default(measure_frame())
+    env._set_default_login(LOGIN_SUCCESS_FRAME)
+    await coord._async_update_data()
+    await coord._async_update_data()  # same live connection
+
+    client = env.clients[-1]
+    assert written_commands(client).count(0x17) == 1
+    assert coord.measurement_count == 2
+
+
+async def test_login_timeout_governed_by_login_timeout(env, monkeypatch):
+    # LOGIN_TIMEOUT small, MEASURE_TIMEOUT large: a regression wiring login to
+    # MEASURE_TIMEOUT would block ~2s and blow the wall-clock bound.
+    monkeypatch.setattr(coord_mod, "LOGIN_TIMEOUT", 0.1)
+    monkeypatch.setattr(coord_mod, "MEASURE_TIMEOUT", 2.0)
+    coord = env.build_coord("1234")
+    env._set_default_login(None)  # no login frame -> the login wait times out
+
+    start = time.monotonic()
+    with pytest.raises(UpdateFailed):
+        await coord._async_update_data()
+    elapsed = time.monotonic() - start
+    assert elapsed < 1.0
+
+
+async def test_login_failure_frame_raises_auth_failed(env):
+    coord = env.build_coord("1234")
+    env._set_default_login(LOGIN_FAILURE_FRAME)
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coord._async_ensure_connected()
+    assert coord.client is None
+    assert env.clients[-1].is_connected is False  # orphan disconnected
+
+
+async def test_reauth_wiring_on_failure_frame(hass, env):
+    coord = env.build_coord("1234")
+    env._set_default_login(LOGIN_FAILURE_FRAME)
+    await coord.async_refresh()
+    await hass.async_block_till_done()  # async_start_reauth inits the flow on a task
+    assert coord.last_update_success is False
+    assert len(reauth_flows(hass, env.entry)) == 1
+
+
+async def test_reauth_non_accumulation(hass, env):
+    coord = env.build_coord("1234")
+    env._set_default_login(LOGIN_FAILURE_FRAME)
+    await coord.async_refresh()
+    await hass.async_block_till_done()
+    await coord.async_refresh()
+    await hass.async_block_till_done()
+    assert len(reauth_flows(hass, env.entry)) == 1  # async_start_reauth is idempotent
+
+
+async def test_login_timeout_does_not_start_reauth(hass, env):
+    coord = env.build_coord("1234")
+    env._set_default_login(None)  # silent firmware: login times out
+    await coord.async_refresh()
+    await hass.async_block_till_done()
+    assert coord.last_update_success is False
+    assert reauth_flows(hass, env.entry) == []  # transient -> no reauth
+
+
+async def test_login_write_bleak_error_does_not_start_reauth(hass, env):
+    coord = env.build_coord("1234")
+
+    def _establish(*args, **kwargs):
+        client = FakeClient()
+        client.raise_on_login_write = True
+        env.clients.append(client)
+        return client
+
+    env.establish_mock.side_effect = _establish
+    await coord.async_refresh()
+    await hass.async_block_till_done()
+    assert coord.last_update_success is False
+    assert reauth_flows(hass, env.entry) == []
+    assert coord.client is None
+    assert env.clients[-1].is_connected is False
+    assert not coord._operation_lock.locked()
+
+
+async def test_login_timeout_warning_gated(env, caplog):
+    coord = env.build_coord("1234")
+    env._set_default_login(None)
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(UpdateFailed):
+            await coord._async_update_data()  # first connect: warning + UpdateFailed
+        coord.client = None  # force a fresh connect next cycle
+        with pytest.raises(UpdateFailed):
+            await coord._async_update_data()  # second timeout, same episode
+    assert sum("Login to" in r.message for r in caplog.records) == 1
+
+
+async def test_login_timeout_warning_rearmed_after_success(env, caplog):
+    coord = env.build_coord("1234")
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        env._set_default_login(None)
+        with pytest.raises(UpdateFailed):
+            await coord._async_update_data()  # warning #1
+
+        env._set_default_login(LOGIN_SUCCESS_FRAME)
+        env._set_default(measure_frame())
+        await coord._async_update_data()  # success clears the gate
+
+        env._set_default_login(None)
+        coord.client.is_connected = False
+        with pytest.raises(UpdateFailed):
+            await coord._async_update_data()  # warning #2 (re-armed)
+    assert sum("Login to" in r.message for r in caplog.records) == 2
+
+
+async def test_no_pin_timeout_logs_no_warning(env, caplog):
+    env._set_default(None)  # device never answers MEASURE; no PIN configured
+    import logging
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(UpdateFailed):
+            await env.coord._async_update_data()
+    assert not any("Login to" in r.message for r in caplog.records)
+
+
+async def test_login_timeout_on_reconnect_immediate(env):
+    coord = env.build_coord("1234")
+    env._set_default(measure_frame())
+    env._set_default_login(LOGIN_SUCCESS_FRAME)
+    await coord._async_update_data()  # seed one good measurement
+    assert coord._missed_updates == 0
+
+    prior = coord.client
+    coord.client.is_connected = False
+    env._set_default_login(None)  # reconnect login goes silent
+    with pytest.raises(UpdateFailed):
+        await coord._async_update_data()  # immediate, no missed-update tolerance
+    assert coord._missed_updates == 0
+    assert coord.client is prior  # stale client kept (replaced on the next reconnect)
+    assert env.clients[-1].is_connected is False  # fresh orphan disconnected
+
+
+async def test_invalid_stored_pin_raises_auth_failed(env):
+    coord = env.build_coord("12")  # malformed stored PIN
+    with pytest.raises(ConfigEntryAuthFailed):
+        await coord._async_ensure_connected()
+
+
+async def test_stale_login_result_not_reused(env):
+    coord = env.build_coord("1234")
+    env._set_default(measure_frame())
+    env._set_default_login(LOGIN_SUCCESS_FRAME)
+    await coord._async_update_data()  # _login_result True, _login_count 1
+
+    coord.client.is_connected = False
+    env._set_default_login(None)  # no login frame on reconnect
+    with pytest.raises(UpdateFailed):
+        await coord._async_update_data()  # must time out, not re-read the stale True
+
+
+async def test_malformed_login_frame_mid_login(env):
+    coord = env.build_coord("1234")
+
+    def _establish(*args, **kwargs):
+        client = FakeClient()
+        client.auto_login_frame = bytearray([0x0F, 0x02, 0x17, 0x00, 0xFF, 0xFF])  # garbage
+        env.clients.append(client)
+        return client
+
+    env.establish_mock.side_effect = _establish
+    with pytest.raises(UpdateFailed):
+        await coord._async_ensure_connected()
+    assert coord.client is None
+
+
+async def test_reconnect_resends_login_before_measure(env):
+    coord = env.build_coord("1234")
+    env._set_default(measure_frame())
+    env._set_default_login(LOGIN_SUCCESS_FRAME)
+    await coord._async_update_data()
+
+    coord.client.is_connected = False
+    await coord._async_update_data()  # reconnect
+    client = env.clients[-1]  # the fresh client
+    assert written_commands(client).index(0x17) < written_commands(client).index(0x04)
+
+
+async def test_steady_state_reauth_two_cycles(hass, env):
+    coord = env.build_coord("1234")
+    env._set_default(measure_frame())
+    env._set_default_login(LOGIN_SUCCESS_FRAME)
+    await coord._async_update_data()  # one good measurement
+    prior_client = coord.client
+
+    env._set_default_login(LOGIN_FAILURE_FRAME)
+    for _ in range(2):
+        coord.client.is_connected = False
+        with pytest.raises(ConfigEntryAuthFailed):
+            await coord._async_update_data()
+        assert coord._missed_updates == 0
+        assert coord.client is prior_client  # retained: not nulled, not the orphan
+        assert env.clients[-1].is_connected is False  # fresh orphan disconnected
+
+
+async def test_switch_happy_path_with_pin(env):
+    coord = env.build_coord("1234")
+    env._set_default_login(LOGIN_SUCCESS_FRAME)
+    await coord.async_send_switch_command(coord_mod.SwitchModes.ON)
+    client = env.clients[-1]
+    assert written_commands(client).index(0x17) < written_commands(client).index(0x03)
+
+
+async def test_switch_auth_failure_wrapped_no_reauth(hass, env):
+    coord = env.build_coord("1234")
+    env._set_default_login(LOGIN_FAILURE_FRAME)
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await coord.async_send_switch_command(coord_mod.SwitchModes.ON)
+    await hass.async_block_till_done()
+    assert not isinstance(exc_info.value, ConfigEntryAuthFailed)
+    assert "Failed to send switch command" in str(exc_info.value)
+    assert reauth_flows(hass, env.entry) == []  # switch path does not spawn reauth
+
+
+async def test_switch_transient_login_failure_wrapped(hass, env):
+    coord = env.build_coord("1234")
+
+    def _establish(*args, **kwargs):
+        client = FakeClient()
+        client.raise_on_login_write = True
+        env.clients.append(client)
+        return client
+
+    env.establish_mock.side_effect = _establish
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await coord.async_send_switch_command(coord_mod.SwitchModes.ON)
+    await hass.async_block_till_done()
+    assert not isinstance(exc_info.value, ConfigEntryAuthFailed)
+    assert not isinstance(exc_info.value, UpdateFailed)
+    assert reauth_flows(hass, env.entry) == []
+    assert not coord._operation_lock.locked()
+
+
+async def test_operation_lock_released_while_login_parked(env):
+    coord = env.build_coord("1234")
+    env._set_default_login(None)  # deliver manually so login parks on the cond
+    task = asyncio.create_task(coord._async_ensure_connected())
+    await asyncio.sleep(0.02)
+
+    assert not coord._operation_lock.locked()  # released before the cond await
+    await env.clients[-1].deliver_frame(LOGIN_SUCCESS_FRAME)
+    await task
+    assert coord.client is not None
+
+
+async def test_cross_isolation_measure_does_not_satisfy_login(env, monkeypatch):
+    monkeypatch.setattr(coord_mod, "LOGIN_TIMEOUT", 1.0)
+    coord = env.build_coord("1234")
+    env._set_default_login(None)
+    task = asyncio.create_task(coord._async_ensure_connected())
+    await asyncio.sleep(0.02)  # login parked on _login_cond
+
+    login_count_before = coord._login_count
+    await coord._handle_notify(None, measure_frame())  # a MEASURE frame, not LOGIN
+    await asyncio.sleep(0.02)
+    assert coord._login_count == login_count_before  # login NOT satisfied
+    assert not task.done()
+    assert coord.measurement_count == 1  # routed to the measure path
+
+    await env.clients[-1].deliver_frame(LOGIN_SUCCESS_FRAME)
+    await task  # login now completes
+
+
+async def test_cross_isolation_login_does_not_satisfy_measure(env, monkeypatch):
+    monkeypatch.setattr(coord_mod, "MEASURE_TIMEOUT", 0.2)
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()  # connect (no PIN)
+    count_before = env.coord.measurement_count
+
+    env.clients[-1].auto_measure_frame = None
+    task = asyncio.create_task(env.coord._async_update_data())
+    await asyncio.sleep(0.02)
+    await env.coord._handle_notify(None, LOGIN_SUCCESS_FRAME)  # a LOGIN frame mid measure-wait
+
+    result = await task
+    assert result is not None  # measure timed out -> last data
+    assert env.coord.measurement_count == count_before  # login frame did not complete the measure
+
+
+async def test_stray_login_frame_is_harmless(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    count_before = env.coord.measurement_count
+    login_count_before = env.coord._login_count
+
+    await env.coord._handle_notify(None, LOGIN_SUCCESS_FRAME)  # no login pending
+    assert env.coord._login_count == login_count_before + 1
+    assert env.coord.measurement_count == count_before

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,469 @@
+"""Tests for the coordinator's update/timeout/reconnect state machine.
+
+Driven with a fake BleakClient and the Home Assistant test harness. The
+module-level MEASURE_TIMEOUT is patched small so timed-out cycles are fast.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from bleak.exc import BleakError
+
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.voltcraft_sem6000_spb012ble import coordinator as coord_mod
+from custom_components.voltcraft_sem6000_spb012ble.coordinator import (
+    VoltcraftData,
+    VoltcraftDataUpdateCoordinator,
+)
+from custom_components.voltcraft_sem6000_spb012ble.protocol import MeasureNotifyPayload
+
+RAW_MAC = "AA:BB:CC:DD:EE:FF"
+FORMATTED_MAC = "aa:bb:cc:dd:ee:ff"
+
+MEASURE_ARGS = bytearray([0x01, 0x00, 0x05, 0xDC, 0xE6, 0x00, 0xFA, 0x32, 0xAB, 0xCD, 0x04, 0xD2])
+
+
+def measure_frame() -> bytearray:
+    params = bytearray([0x04, 0x00]) + MEASURE_ARGS
+    body = params + bytearray([0x00])
+    return bytearray([0x0F, len(body)]) + body + bytearray([0xFF, 0xFF])
+
+
+def switch_frame() -> bytearray:
+    params = bytearray([0x03, 0x00, 0x01])
+    body = params + bytearray([0x00])
+    return bytearray([0x0F, len(body)]) + body + bytearray([0xFF, 0xFF])
+
+
+class FakeClient:
+    def __init__(self) -> None:
+        self.is_connected = True
+        self.notify_cb = None
+        self.written: list[bytes] = []
+        self.stopped = False
+        self.disconnect_error = False
+        self.raise_on_write = False
+        self.hang_on_write = False
+        self.auto_measure_frame: bytearray | None = None
+
+    async def start_notify(self, uuid, cb) -> None:
+        self.notify_cb = cb
+
+    async def stop_notify(self, uuid) -> None:
+        self.stopped = True
+
+    async def write_gatt_char(self, uuid, data) -> None:
+        if self.raise_on_write:
+            raise BleakError("write failed")
+        if self.hang_on_write:
+            await asyncio.Event().wait()  # never resolves; relies on the caller's timeout
+        self.written.append(bytes(data))
+        if self.auto_measure_frame is not None and bytes(data)[2] == 0x04:
+            asyncio.get_running_loop().create_task(self._deliver(self.auto_measure_frame))
+
+    async def _deliver(self, frame: bytearray) -> None:
+        if self.notify_cb is not None:
+            await self.notify_cb(None, frame)
+
+    async def deliver_measure(self, frame: bytearray) -> None:
+        await self.notify_cb(None, frame)
+
+    async def disconnect(self) -> None:
+        if self.disconnect_error:
+            raise BleakError("disconnect failed")
+        self.is_connected = False
+
+
+@dataclass
+class Env:
+    coord: VoltcraftDataUpdateCoordinator
+    establish_mock: AsyncMock
+    lookup_mock: MagicMock
+    clients: list[FakeClient]
+
+
+@pytest.fixture
+def env(hass, monkeypatch):
+    ble_device = SimpleNamespace(name="Test Plug", address=RAW_MAC)
+    clients: list[FakeClient] = []
+    state = {"default_frame": None}
+
+    def _establish(*args, **kwargs):
+        client = FakeClient()
+        client.auto_measure_frame = state["default_frame"]
+        clients.append(client)
+        return client
+
+    establish_mock = AsyncMock(side_effect=_establish)
+    lookup_mock = MagicMock(return_value=ble_device)
+
+    monkeypatch.setattr(coord_mod, "MEASURE_TIMEOUT", 0.1)
+    monkeypatch.setattr(coord_mod, "establish_connection", establish_mock)
+    monkeypatch.setattr(coord_mod.bluetooth, "async_ble_device_from_address", lookup_mock)
+
+    coord = VoltcraftDataUpdateCoordinator(hass, RAW_MAC, ble_device)
+
+    holder = Env(coord, establish_mock, lookup_mock, clients)
+
+    def _set_default(frame):
+        state["default_frame"] = frame
+
+    holder._set_default = _set_default  # type: ignore[attr-defined]
+    return holder
+
+
+async def test_happy_path_returns_new_data(env):
+    env._set_default(measure_frame())
+    data = await env.coord._async_update_data()
+    assert isinstance(data, VoltcraftData)
+    assert data.is_on is True
+    assert data.power == 1.5
+    assert data.voltage == 230.0
+    assert data.current == 0.25
+    assert data.consumed_energy == 1.234
+    assert env.coord.measurement_count == 1
+
+
+def test_power_factor_none_when_no_apparent_power():
+    for voltage, current in ((230, 0), (0, 250)):
+        payload = MeasureNotifyPayload(
+            is_on=True, power=1500, voltage=voltage, current=current, frequency=50, consumed_energy=1234
+        )
+        assert VoltcraftData.from_payload(payload).power_factor is None
+
+
+def test_power_factor_clamped_to_one():
+    payload = MeasureNotifyPayload(is_on=True, power=1_000_000, voltage=10, current=10, frequency=50, consumed_energy=0)
+    assert VoltcraftData.from_payload(payload).power_factor == 1.0
+
+
+def test_power_factor_representative_value():
+    # power 1.15 W, voltage 230 V, current 0.01 A -> apparent 2.3 -> pf 0.5
+    payload = MeasureNotifyPayload(is_on=True, power=1150, voltage=230, current=10, frequency=50, consumed_energy=0)
+    assert VoltcraftData.from_payload(payload).power_factor == pytest.approx(0.5)
+
+
+async def test_single_timeout_returns_last_data(env):
+    env._set_default(measure_frame())
+    last = await env.coord._async_update_data()
+
+    env.clients[-1].auto_measure_frame = None  # stop delivering notifications
+    result = await env.coord._async_update_data()
+    assert result == last
+    assert env.coord._missed_updates == 1
+
+
+async def test_max_missed_updates_raises(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    env.clients[-1].auto_measure_frame = None
+
+    assert await env.coord._async_update_data() is not None  # miss 1
+    assert await env.coord._async_update_data() is not None  # miss 2
+    with pytest.raises(UpdateFailed):  # miss 3 -> threshold
+        await env.coord._async_update_data()
+    assert env.coord.client is None
+
+
+async def test_first_refresh_with_no_data_raises(env):
+    env._set_default(None)  # device never answers
+    with pytest.raises(UpdateFailed):
+        await env.coord._async_update_data()
+    assert env.coord.client is None
+
+
+async def test_missed_counter_resets_on_measurement(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    env.clients[-1].auto_measure_frame = None
+    await env.coord._async_update_data()  # miss 1
+    assert env.coord._missed_updates == 1
+
+    env.clients[-1].auto_measure_frame = measure_frame()
+    await env.coord._async_update_data()
+    assert env.coord._missed_updates == 0
+
+
+async def test_concurrent_cycles_share_one_measurement(env, monkeypatch):
+    monkeypatch.setattr(coord_mod, "MEASURE_TIMEOUT", 1.0)
+    env._set_default(None)  # deliver manually
+    t1 = asyncio.create_task(env.coord._async_update_data())
+    t2 = asyncio.create_task(env.coord._async_update_data())
+    await asyncio.sleep(0.05)  # both reach the measurement wait
+
+    await env.coord._handle_notify(None, measure_frame())  # a single measurement
+    d1 = await t1
+    d2 = await t2
+    assert isinstance(d1, VoltcraftData)
+    assert isinstance(d2, VoltcraftData)
+    assert env.coord._missed_updates == 0  # neither cycle spuriously missed
+
+
+async def test_malformed_frame_does_not_complete_cycle(env, monkeypatch):
+    monkeypatch.setattr(coord_mod, "MEASURE_TIMEOUT", 0.2)
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    count_before = env.coord.measurement_count
+
+    env.clients[-1].auto_measure_frame = None
+    task = asyncio.create_task(env.coord._async_update_data())
+    await asyncio.sleep(0.02)
+    await env.coord._handle_notify(None, bytearray([0x0F, 0x02, 0x04, 0x00, 0xFF, 0xFF]))
+
+    result = await task
+    assert result is not None  # times out -> last data, below the miss budget
+    assert env.coord.measurement_count == count_before  # garbage did not count
+    assert env.coord._missed_updates == 1
+
+
+async def test_half_open_link_reconnects(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    assert env.establish_mock.call_count == 1
+
+    env.coord.client.is_connected = False  # half-open: assigned but dead
+    await env.coord._async_ensure_connected()
+    assert env.establish_mock.call_count == 2
+    assert env.coord._missed_updates == 0
+    assert env.clients[-1].notify_cb is not None  # start_notify re-registered
+
+
+async def test_connect_failure_raises_update_failed(env):
+    env.establish_mock.side_effect = BleakError("unreachable")
+    with pytest.raises(UpdateFailed):
+        await env.coord._async_update_data()
+
+
+async def test_hung_write_times_out_as_miss(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()  # connect + seed self.data
+
+    env.clients[-1].hang_on_write = True
+    result = await env.coord._async_update_data()  # write hangs -> timeout -> miss
+    assert result is not None  # last data returned, below the miss budget
+    assert env.coord._missed_updates == 1
+
+
+async def test_hung_switch_write_raises(env):
+    await env.coord._async_ensure_connected()
+    env.clients[-1].hang_on_write = True
+    with pytest.raises(HomeAssistantError):
+        await env.coord.async_send_switch_command(coord_mod.SwitchModes.ON)
+
+
+async def test_hung_start_notify_raises_update_failed(env):
+    bad = FakeClient()
+
+    async def _hang_start_notify(uuid, cb):
+        await asyncio.Event().wait()
+
+    bad.start_notify = _hang_start_notify
+    env.establish_mock.side_effect = lambda *args, **kwargs: bad
+
+    with pytest.raises(UpdateFailed):
+        await env.coord._async_ensure_connected()
+    assert env.coord.client is None
+    assert bad.is_connected is False  # guard-disconnected after the timeout
+
+
+async def test_start_notify_failure_disconnects_client(env):
+    bad = FakeClient()
+
+    async def _bad_start_notify(uuid, cb):
+        raise BleakError("notify failed")
+
+    bad.start_notify = _bad_start_notify
+    env.establish_mock.side_effect = lambda *args, **kwargs: bad
+
+    with pytest.raises(UpdateFailed):
+        await env.coord._async_ensure_connected()
+    assert bad.is_connected is False  # orphaned client was disconnected
+    assert env.coord.client is None
+
+
+async def test_ensure_connected_already_connected_is_noop(env):
+    await env.coord._async_ensure_connected()
+    await env.coord._async_ensure_connected()
+    assert env.establish_mock.call_count == 1
+
+
+async def test_concurrent_connect_establishes_once(env):
+    gate = asyncio.Event()
+
+    async def _gated_establish(*args, **kwargs):
+        await gate.wait()
+        client = FakeClient()
+        client.auto_measure_frame = measure_frame()
+        env.clients.append(client)
+        return client
+
+    env.establish_mock.side_effect = _gated_establish
+
+    t1 = asyncio.create_task(env.coord._async_ensure_connected())
+    t2 = asyncio.create_task(env.coord._async_ensure_connected())
+    await asyncio.sleep(0.01)  # t1 holds _connect_lock inside establish; t2 blocks on the lock
+    gate.set()
+    await asyncio.gather(t1, t2)
+
+    assert env.establish_mock.call_count == 1  # double-checked lock prevents a duplicate connect
+    assert len(env.clients) == 1
+
+
+async def test_lookup_uses_raw_uppercase_mac(env):
+    await env.coord._async_ensure_connected()
+    env.lookup_mock.assert_called_once()
+    assert env.lookup_mock.call_args.args[1] == RAW_MAC
+    assert env.lookup_mock.call_args.kwargs["connectable"] is True
+    assert env.coord.mac == FORMATTED_MAC
+
+
+async def test_none_device_raises_then_recovers(env):
+    env.lookup_mock.return_value = None
+    with pytest.raises(UpdateFailed):
+        await env.coord._async_update_data()
+
+    env.lookup_mock.return_value = SimpleNamespace(name="Test Plug", address=RAW_MAC)
+    env._set_default(measure_frame())
+    data = await env.coord._async_update_data()
+    assert isinstance(data, VoltcraftData)
+
+
+async def test_reconnect_restores_full_miss_budget(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()  # establish #1
+    env.clients[-1].auto_measure_frame = None
+    await env.coord._async_update_data()  # miss 1
+    await env.coord._async_update_data()  # miss 2
+    with pytest.raises(UpdateFailed):
+        await env.coord._async_update_data()  # miss 3 -> teardown
+    assert env.establish_mock.call_count == 1
+
+    env._set_default(None)  # reconnected client also silent
+    await env.coord._async_update_data()  # reconnect #2, miss 1 (budget reset)
+    await env.coord._async_update_data()  # miss 2 -> still below threshold
+    assert env.establish_mock.call_count == 2  # no second teardown/churn
+
+
+async def test_teardown_on_guarded_disconnect_failure(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    env.clients[-1].auto_measure_frame = None
+    env.clients[-1].disconnect_error = True
+
+    await env.coord._async_update_data()
+    await env.coord._async_update_data()
+    with pytest.raises(UpdateFailed):
+        await env.coord._async_update_data()
+    assert env.coord.client is None  # teardown completed despite disconnect error
+
+
+async def test_teardown_does_not_null_a_replacement_client(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    client_a = env.coord.client
+
+    # Pause client_a.disconnect so a reconnect can interleave during the await.
+    gate = asyncio.Event()
+
+    async def _gated_disconnect():
+        client_a.is_connected = False
+        await gate.wait()
+
+    client_a.disconnect = _gated_disconnect
+
+    teardown_task = asyncio.create_task(env.coord._async_teardown())
+    await asyncio.sleep(0.01)  # teardown now blocked inside disconnect
+
+    client_b = await env.coord._async_ensure_connected()  # establishes a fresh client
+    assert client_b is not client_a
+    assert env.coord.client is client_b
+
+    gate.set()
+    await teardown_task
+    assert env.coord.client is client_b  # the replacement was not discarded
+
+
+async def test_async_shutdown_with_no_client_does_not_raise(env):
+    await env.coord.async_shutdown()  # client is None
+
+
+async def test_async_shutdown_tolerates_bleak_errors(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+
+    async def _raise(uuid):
+        raise BleakError("boom")
+
+    env.coord.client.stop_notify = _raise
+    env.coord.client.disconnect_error = True
+    await env.coord.async_shutdown()  # must not propagate
+
+
+async def test_async_shutdown_disconnects(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    client = env.coord.client
+    await env.coord.async_shutdown()
+    assert client.stopped is True
+    assert env.coord.client.is_connected is False
+
+
+async def test_switch_notification_triggers_refresh(env):
+    env._set_default(measure_frame())
+    await env.coord._async_update_data()
+    env.coord.async_request_refresh = AsyncMock()
+
+    await env.coord._handle_notify(None, switch_frame())
+    await asyncio.sleep(0.01)
+    env.coord.async_request_refresh.assert_called()
+
+
+async def test_switch_command_reraises_bleak_error(env):
+    await env.coord._async_ensure_connected()
+    env.clients[-1].raise_on_write = True
+    with pytest.raises(HomeAssistantError):
+        await env.coord.async_send_switch_command(coord_mod.SwitchModes.ON)
+    assert env.establish_mock.call_count == 1  # ensure-first still ran
+
+
+async def test_switch_command_device_not_found_raises_home_assistant_error(env):
+    env.lookup_mock.return_value = None  # unreachable -> _async_ensure_connected raises UpdateFailed
+    with pytest.raises(HomeAssistantError) as exc_info:
+        await env.coord.async_send_switch_command(coord_mod.SwitchModes.ON)
+    # Must be the wrapped error, not the raw UpdateFailed (which is also a HomeAssistantError).
+    assert not isinstance(exc_info.value, UpdateFailed)
+    assert "Failed to send switch command" in str(exc_info.value)
+
+
+async def test_operation_lock_serializes_switch_write(env):
+    await env.coord._async_ensure_connected()
+    await env.coord._operation_lock.acquire()
+    task = asyncio.create_task(env.coord.async_send_switch_command(coord_mod.SwitchModes.ON))
+    await asyncio.sleep(0.01)
+    assert env.clients[-1].written == []  # write blocked by held lock
+
+    env.coord._operation_lock.release()
+    await task
+    assert any(w[2] == 0x03 for w in env.clients[-1].written)  # switch write happened
+
+
+async def test_operation_lock_released_before_measure_await(env, monkeypatch):
+    monkeypatch.setattr(coord_mod, "MEASURE_TIMEOUT", 1.0)
+    env._set_default(None)  # do not auto-deliver; we deliver manually
+    update_task = asyncio.create_task(env.coord._async_update_data())
+    await asyncio.sleep(0.02)  # let the cycle reach the measure-event await
+
+    assert not env.coord._operation_lock.locked()
+    await asyncio.wait_for(env.coord._operation_lock.acquire(), 0.1)
+    env.coord._operation_lock.release()
+
+    await env.clients[-1].deliver_measure(measure_frame())
+    data = await update_task
+    assert isinstance(data, VoltcraftData)

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,43 @@
+"""Tests for integration setup."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.const import CONF_MAC
+from homeassistant.exceptions import ConfigEntryNotReady
+
+import custom_components.voltcraft_sem6000_spb012ble as integration
+from custom_components.voltcraft_sem6000_spb012ble.const import DOMAIN
+from custom_components.voltcraft_sem6000_spb012ble.coordinator import VoltcraftDataUpdateCoordinator
+
+ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+
+async def test_setup_entry_device_not_found_raises_not_ready(hass, monkeypatch):
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: ADDRESS})
+    entry.add_to_hass(hass)
+    monkeypatch.setattr(integration.bluetooth, "async_ble_device_from_address", lambda *args, **kwargs: None)
+    with pytest.raises(ConfigEntryNotReady):
+        await integration.async_setup_entry(hass, entry)
+
+
+async def test_setup_entry_success_stores_coordinator_and_forwards(hass, monkeypatch):
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: ADDRESS})
+    entry.add_to_hass(hass)
+    device = SimpleNamespace(name="Test Plug", address=ADDRESS)
+    lookup = MagicMock(return_value=device)
+    monkeypatch.setattr(integration.bluetooth, "async_ble_device_from_address", lookup)
+    # Avoid real BLE work: the first refresh and platform forwarding are stubbed.
+    monkeypatch.setattr(VoltcraftDataUpdateCoordinator, "async_config_entry_first_refresh", AsyncMock())
+    forward = AsyncMock(return_value=True)
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", forward)
+
+    assert await integration.async_setup_entry(hass, entry) is True
+    assert isinstance(hass.data[DOMAIN][entry.entry_id], VoltcraftDataUpdateCoordinator)
+    assert lookup.call_args.kwargs["connectable"] is True  # only connectable adverts
+    forward.assert_awaited_once()

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -8,14 +8,26 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
-from homeassistant.const import CONF_MAC
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.const import CONF_MAC, CONF_PIN
+from homeassistant.exceptions import ConfigEntryAuthFailed, ConfigEntryNotReady
 
 import custom_components.voltcraft_sem6000_spb012ble as integration
 from custom_components.voltcraft_sem6000_spb012ble.const import DOMAIN
 from custom_components.voltcraft_sem6000_spb012ble.coordinator import VoltcraftDataUpdateCoordinator
+from tests.ble_harness import FakeClient
 
 ADDRESS = "AA:BB:CC:DD:EE:FF"
+
+
+def _stub_setup(hass, monkeypatch, *, first_refresh=None):
+    device = SimpleNamespace(name="Test Plug", address=ADDRESS)
+    monkeypatch.setattr(integration.bluetooth, "async_ble_device_from_address", MagicMock(return_value=device))
+    monkeypatch.setattr(
+        VoltcraftDataUpdateCoordinator,
+        "async_config_entry_first_refresh",
+        first_refresh or AsyncMock(),
+    )
+    monkeypatch.setattr(hass.config_entries, "async_forward_entry_setups", AsyncMock(return_value=True))
 
 
 async def test_setup_entry_device_not_found_raises_not_ready(hass, monkeypatch):
@@ -41,3 +53,50 @@ async def test_setup_entry_success_stores_coordinator_and_forwards(hass, monkeyp
     assert isinstance(hass.data[DOMAIN][entry.entry_id], VoltcraftDataUpdateCoordinator)
     assert lookup.call_args.kwargs["connectable"] is True  # only connectable adverts
     forward.assert_awaited_once()
+
+
+async def test_setup_forwards_pin_and_entry(hass, monkeypatch):
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: ADDRESS, CONF_PIN: "1234"})
+    entry.add_to_hass(hass)
+    _stub_setup(hass, monkeypatch)
+
+    assert await integration.async_setup_entry(hass, entry) is True
+    coord = hass.data[DOMAIN][entry.entry_id]
+    assert coord._pin == "1234"
+    assert coord.config_entry is entry
+
+
+async def test_setup_forwards_none_pin_for_entry_without_one(hass, monkeypatch):
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: ADDRESS})
+    entry.add_to_hass(hass)
+    _stub_setup(hass, monkeypatch)
+
+    assert await integration.async_setup_entry(hass, entry) is True
+    assert hass.data[DOMAIN][entry.entry_id]._pin is None
+
+
+async def test_first_refresh_auth_failed_propagates_as_reauth(hass, monkeypatch):
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    entry.add_to_hass(hass)
+    _stub_setup(hass, monkeypatch, first_refresh=AsyncMock(side_effect=ConfigEntryAuthFailed("bad pin")))
+
+    # Must surface as auth failure (reauth), NOT be masked as ConfigEntryNotReady.
+    with pytest.raises(ConfigEntryAuthFailed):
+        await integration.async_setup_entry(hass, entry)
+
+
+async def test_unload_entry_shuts_down_cleanly(hass, monkeypatch):
+    entry = MockConfigEntry(domain=DOMAIN, data={CONF_MAC: ADDRESS})
+    entry.add_to_hass(hass)
+    _stub_setup(hass, monkeypatch)
+    assert await integration.async_setup_entry(hass, entry) is True
+
+    coord = hass.data[DOMAIN][entry.entry_id]
+    client = FakeClient()
+    coord.client = client  # a live client so shutdown traverses stop_notify/disconnect
+    monkeypatch.setattr(hass.config_entries, "async_unload_platforms", AsyncMock(return_value=True))
+
+    assert await integration.async_unload_entry(hass, entry) is True
+    assert client.stopped is True
+    assert client.is_connected is False
+    assert coord.client is None

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -12,10 +12,12 @@ import pytest
 
 from custom_components.voltcraft_sem6000_spb012ble.protocol import (
     Command,
+    LoginNotifyPayload,
     MeasureNotifyPayload,
     NotifyPayload,
     SwitchModes,
     SwitchNotifyPayload,
+    LoginCommand,
 )
 
 # Synthesized 12-byte (hw v3, 2-byte energy) MEASURE argument block.
@@ -136,3 +138,47 @@ def test_switch_build_to_from_payload_round_trip():
 )
 def test_malformed_payload_returns_none(payload):
     assert NotifyPayload.from_payload(payload) is None
+
+
+def test_build_login_payload_zero_pin_matches_reference_frame():
+    # Byte-identical to the community-reverse-engineered static "0000" login frame.
+    assert LoginCommand.build_payload("0000") == bytearray.fromhex("0f0c170000000000000000000018ffff")
+
+
+def test_build_login_payload_encodes_digits_one_byte_each():
+    payload = LoginCommand.build_payload("1234")
+    # frame = [0x0F, len, cmd, 0x00, *params, checksum, 0xFF, 0xFF];
+    # params = [0x00] + digit bytes + [0,0,0,0], so digit bytes for "1234" sit at [5:9].
+    assert payload[5:9] == bytearray([0x01, 0x02, 0x03, 0x04])
+    # Round-trips through the shared framing: header, length, command, checksum, footer.
+    assert payload[0] == 0x0F and payload[1] == 0x0C and payload[2] == Command.LOGIN
+    assert payload[-2:] == bytearray([0xFF, 0xFF])
+
+
+@pytest.mark.parametrize("pin", ["", "123", "12345", "12a4", " 12 ", "12.4", "١٢٣٤", "１２３４"])
+def test_normalize_pin_and_build_reject_invalid(pin):
+    with pytest.raises(ValueError):
+        LoginCommand.normalize_pin(pin)
+    with pytest.raises(ValueError):
+        LoginCommand.build_payload(pin)
+
+
+def test_normalize_pin_strips_and_returns_value():
+    assert LoginCommand.normalize_pin(" 1234 ") == "1234"
+    assert LoginCommand.normalize_pin("0000") == "0000"
+
+
+def test_login_response_frames_parse_to_status():
+    success = NotifyPayload.from_payload(bytearray.fromhex("0f06170000000018ffff"))
+    assert isinstance(success, LoginNotifyPayload)
+    assert success.was_successful is True
+
+    failure = NotifyPayload.from_payload(bytearray.fromhex("0f06170001000018ffff"))
+    assert isinstance(failure, LoginNotifyPayload)
+    assert failure.was_successful is False
+
+
+def test_truncated_login_frame_returns_none():
+    # Valid framing but no status byte: arguments are empty after the command/separator
+    # split, so LoginNotifyPayload.from_data hits its len(data) < 1 guard.
+    assert NotifyPayload.from_payload(bytearray([0x0F, 0x03, Command.LOGIN, 0x00, 0x00, 0xFF, 0xFF])) is None

--- a/tests/test_protocol.py
+++ b/tests/test_protocol.py
@@ -1,0 +1,138 @@
+"""Unit tests for the reverse-engineered BLE protocol.
+
+No physical device or original nRF Connect capture is available in the repo, so
+the fixtures are synthesized from the documented byte layout in ``protocol.py``
+(the contract under test). The ``build_payload`` -> ``from_payload`` round-trip
+test independently cross-checks the framing without relying on those offsets.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from custom_components.voltcraft_sem6000_spb012ble.protocol import (
+    Command,
+    MeasureNotifyPayload,
+    NotifyPayload,
+    SwitchModes,
+    SwitchNotifyPayload,
+)
+
+# Synthesized 12-byte (hw v3, 2-byte energy) MEASURE argument block.
+MEASURE_ARGS_12 = bytearray(
+    [
+        0x01,  # is_on
+        0x00,
+        0x05,
+        0xDC,  # power = 1500
+        0xE6,  # voltage = 230
+        0x00,
+        0xFA,  # current = 250
+        0x32,  # frequency = 50
+        0xAB,
+        0xCD,  # padding (ignored)
+        0x04,
+        0xD2,  # consumed_energy = 1234
+    ]
+)
+
+# Synthesized 14-byte (hw v2, 4-byte energy) variant with the same fields.
+MEASURE_ARGS_14 = bytearray(
+    [
+        0x01,
+        0x00,
+        0x05,
+        0xDC,
+        0xE6,
+        0x00,
+        0xFA,
+        0x32,
+        0xAB,
+        0xCD,
+        0x00,
+        0x00,
+        0x04,
+        0xD2,  # consumed_energy = 1234 (4 bytes)
+    ]
+)
+
+
+def make_notify(command: int, arguments: bytearray | list[int]) -> bytearray:
+    """Wrap a command + argument block in the notification framing.
+
+    Layout: 0x0F, length, command, 0x00 (unknown), *arguments, checksum, 0xFF 0xFF.
+    The checksum is irrelevant (device validation is disabled) so it is 0x00.
+    """
+    params = bytearray([command, 0x00]) + bytearray(arguments)
+    body = params + bytearray([0x00])  # trailing checksum byte
+    return bytearray([0x0F, len(body)]) + body + bytearray([0xFF, 0xFF])
+
+
+def test_measure_build_payload_exact_bytes():
+    assert Command.MEASURE.build_payload() == bytearray([0x0F, 0x03, 0x04, 0x00, 0x05, 0xFF, 0xFF])
+
+
+def test_switch_on_build_payload_exact_bytes():
+    assert SwitchModes.ON.build_payload() == bytearray([0x0F, 0x04, 0x03, 0x00, 0x01, 0x05, 0xFF, 0xFF])
+
+
+def test_switch_off_build_payload_exact_bytes():
+    assert SwitchModes.OFF.build_payload() == bytearray([0x0F, 0x04, 0x03, 0x00, 0x00, 0x04, 0xFF, 0xFF])
+
+
+@pytest.mark.parametrize("arguments", [MEASURE_ARGS_12, MEASURE_ARGS_14])
+def test_measure_parse_fields(arguments):
+    payload = NotifyPayload.from_payload(make_notify(Command.MEASURE, arguments))
+    assert isinstance(payload, MeasureNotifyPayload)
+    assert payload.is_on is True
+    assert payload.power == 1500
+    assert payload.voltage == 230
+    assert payload.current == 250
+    assert payload.frequency == 50
+    assert payload.consumed_energy == 1234
+
+
+@pytest.mark.parametrize("arguments", [MEASURE_ARGS_12, MEASURE_ARGS_14])
+def test_padding_bytes_do_not_influence_output(arguments):
+    """Offsets 8-9 are padding (NOT power_factor) — varying them changes nothing."""
+    baseline = NotifyPayload.from_payload(make_notify(Command.MEASURE, arguments))
+    mutated = bytearray(arguments)
+    mutated[8] = 0x11
+    mutated[9] = 0x22
+    result = NotifyPayload.from_payload(make_notify(Command.MEASURE, mutated))
+    assert result == baseline
+
+
+def test_overlong_frame_caps_energy_at_four_bytes():
+    # A corrupt over-length frame must not read its whole tail as one huge energy
+    # value (which would spike the TOTAL_INCREASING statistic).
+    args = bytearray(MEASURE_ARGS_14) + bytearray([0xFF] * 6)  # 6 bytes of garbage tail
+    payload = NotifyPayload.from_payload(make_notify(Command.MEASURE, args))
+    assert isinstance(payload, MeasureNotifyPayload)
+    assert payload.consumed_energy == 1234  # only bytes 10:14, garbage tail ignored
+
+
+def test_switch_frame_parses_to_switch_payload():
+    payload = NotifyPayload.from_payload(make_notify(Command.SWITCH, [0x01]))
+    assert isinstance(payload, SwitchNotifyPayload)
+
+
+def test_switch_build_to_from_payload_round_trip():
+    frame = SwitchModes.ON.build_payload()
+    assert isinstance(NotifyPayload.from_payload(frame), SwitchNotifyPayload)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        bytearray(),  # empty
+        bytearray([0x0F]),  # 1 byte
+        bytearray([0x0F, 0x20, 0x04, 0x00, 0x00, 0xFF, 0xFF]),  # length byte overruns buffer
+        bytearray([0x0F, 0x02, 0x04, 0x00, 0xFF, 0xFF]),  # body too short for a command
+        make_notify(0x09, [0x00] * 12),  # unknown command byte
+        make_notify(Command.MEASURE, [0x00] * 8),  # truncated MEASURE arguments (8 bytes)
+        make_notify(Command.MEASURE, [0x00] * 11),  # truncated MEASURE arguments (11 bytes)
+    ],
+)
+def test_malformed_payload_returns_none(payload):
+    assert NotifyPayload.from_payload(payload) is None

--- a/tests/test_recovery.py
+++ b/tests/test_recovery.py
@@ -1,0 +1,133 @@
+"""End-to-end PIN recovery: a wrong/unwanted PIN -> config-flow fix -> the
+coordinator (rebuilt from the updated entry data, as __init__ does on reload)
+reconnects and a measurement succeeds.
+
+The HA reload machinery is exercised in unit form elsewhere; here the focus is the
+cross-component seam: config-flow mutation of entry.data feeding the coordinator.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from homeassistant.const import CONF_MAC, CONF_PIN
+from homeassistant.data_entry_flow import FlowResultType
+
+from custom_components.voltcraft_sem6000_spb012ble import coordinator as coord_mod
+from custom_components.voltcraft_sem6000_spb012ble.const import DOMAIN
+from custom_components.voltcraft_sem6000_spb012ble.coordinator import (
+    VoltcraftData,
+    VoltcraftDataUpdateCoordinator,
+)
+from tests.ble_harness import (
+    FORMATTED_MAC,
+    LOGIN_FAILURE_FRAME,
+    LOGIN_SUCCESS_FRAME,
+    RAW_MAC,
+    FakeClient,
+    measure_frame,
+    written_commands,
+)
+
+ADDRESS = RAW_MAC
+
+
+@pytest.fixture
+def ble(hass, monkeypatch):
+    """A fake BLE stack: each connect yields a FakeClient with the configured frames."""
+    state = {"login_frame": None, "measure_frame": None}
+    clients: list[FakeClient] = []
+
+    def _establish(*args, **kwargs):
+        client = FakeClient()
+        client.auto_login_frame = state["login_frame"]
+        client.auto_measure_frame = state["measure_frame"]
+        clients.append(client)
+        return client
+
+    device = SimpleNamespace(name="Test Plug", address=RAW_MAC)
+    monkeypatch.setattr(coord_mod, "MEASURE_TIMEOUT", 0.1)
+    monkeypatch.setattr(coord_mod, "LOGIN_TIMEOUT", 0.1)
+    monkeypatch.setattr(coord_mod, "establish_connection", AsyncMock(side_effect=_establish))
+    monkeypatch.setattr(coord_mod.bluetooth, "async_ble_device_from_address", MagicMock(return_value=device))
+
+    return SimpleNamespace(state=state, clients=clients, device=device)
+
+
+def _entry(hass, data):
+    entry = MockConfigEntry(domain=DOMAIN, data=data, unique_id=FORMATTED_MAC)
+    entry.add_to_hass(hass)
+    return entry
+
+
+async def _coord_from_entry(hass, ble, entry):
+    """Rebuild the coordinator from entry data exactly as __init__.async_setup_entry does."""
+    coord = VoltcraftDataUpdateCoordinator(hass, entry, RAW_MAC, ble.device, entry.data.get(CONF_PIN))
+    await coord.async_refresh()
+    return coord
+
+
+async def test_reauth_then_login_succeeds(hass, ble, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    monkeypatch.setattr(hass.config_entries, "async_schedule_reload", lambda entry_id: None)
+
+    # Wrong PIN: the device rejects the login, which would trigger HA reauth.
+    ble.state["login_frame"] = LOGIN_FAILURE_FRAME
+    coord = await _coord_from_entry(hass, ble, entry)
+    assert coord.last_update_success is False
+
+    # User completes reauth with the correct PIN; the device now accepts it.
+    result = await entry.start_reauth_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "1234"})
+    assert result["type"] == FlowResultType.ABORT
+    assert entry.data[CONF_PIN] == "1234"
+
+    ble.state["login_frame"] = LOGIN_SUCCESS_FRAME
+    ble.state["measure_frame"] = measure_frame()
+    recovered = await _coord_from_entry(hass, ble, entry)  # rebuilt on reload
+    assert isinstance(recovered.data, VoltcraftData)
+    assert recovered.last_update_success is True
+
+
+async def test_reconfigure_clear_recovers_non_pin_device(hass, ble, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    monkeypatch.setattr(hass.config_entries, "async_schedule_reload", lambda entry_id: None)
+
+    # Device does not use PIN login: it silently ignores the 0x17 frame, so login times out.
+    ble.state["login_frame"] = None
+    ble.state["measure_frame"] = measure_frame()
+    coord = await _coord_from_entry(hass, ble, entry)
+    assert coord.last_update_success is False
+
+    # User clears the PIN via Reconfigure.
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {})
+    assert result["type"] == FlowResultType.ABORT
+    assert CONF_PIN not in entry.data
+
+    recovered = await _coord_from_entry(hass, ble, entry)  # rebuilt with pin=None
+    assert isinstance(recovered.data, VoltcraftData)
+    assert all(0x17 not in written_commands(client) for client in ble.clients[-1:])
+
+
+async def test_reconfigure_change_recovers(hass, ble, monkeypatch):
+    entry = _entry(hass, {CONF_MAC: ADDRESS, CONF_PIN: "0000"})
+    monkeypatch.setattr(hass.config_entries, "async_schedule_reload", lambda entry_id: None)
+
+    ble.state["login_frame"] = LOGIN_FAILURE_FRAME
+    coord = await _coord_from_entry(hass, ble, entry)
+    assert coord.last_update_success is False
+
+    result = await entry.start_reconfigure_flow(hass)
+    result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_PIN: "4321"})
+    assert result["type"] == FlowResultType.ABORT
+    assert entry.data[CONF_PIN] == "4321"
+
+    ble.state["login_frame"] = LOGIN_SUCCESS_FRAME
+    ble.state["measure_frame"] = measure_frame()
+    recovered = await _coord_from_entry(hass, ble, entry)
+    assert isinstance(recovered.data, VoltcraftData)

--- a/tests/test_strings.py
+++ b/tests/test_strings.py
@@ -1,0 +1,73 @@
+"""Guards the config-flow translation keys and strings.json <-> en.json sync.
+
+A custom component loads runtime text from translations/<lang>.json (NOT strings.json),
+and does not resolve [%key:...] references, so en.json must ship literal English and stay
+structurally in sync with the developer-source strings.json.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import custom_components.voltcraft_sem6000_spb012ble as integration
+
+COMPONENT_DIR = Path(integration.__file__).parent
+STRINGS = json.loads((COMPONENT_DIR / "strings.json").read_text())
+EN = json.loads((COMPONENT_DIR / "translations" / "en.json").read_text())
+
+REQUIRED_KEYS = [
+    ("config", "error", "invalid_pin"),
+    ("config", "step", "confirm", "data", "pin"),
+    ("config", "step", "confirm", "data_description", "pin"),
+    ("config", "step", "reauth_confirm", "data", "pin"),
+    ("config", "step", "reauth_confirm", "description"),
+    ("config", "step", "reconfigure", "data", "pin"),
+    ("config", "step", "reconfigure", "description"),
+    ("config", "abort", "reauth_successful"),
+    ("config", "abort", "reconfigure_successful"),
+]
+
+GUIDANCE_KEYS = [
+    ("config", "step", "confirm", "data_description", "pin"),
+    ("config", "step", "reauth_confirm", "description"),
+    ("config", "step", "reconfigure", "description"),
+]
+
+
+def _get(tree, path):
+    for key in path:
+        tree = tree[key]
+    return tree
+
+
+def _key_structure(tree):
+    if isinstance(tree, dict):
+        return {key: _key_structure(value) for key, value in sorted(tree.items())}
+    return None
+
+
+def test_required_keys_present_in_both_files():
+    for path in REQUIRED_KEYS:
+        _get(STRINGS, path)  # raises KeyError if missing
+        _get(EN, path)
+
+
+def test_files_have_identical_key_structure():
+    assert _key_structure(STRINGS) == _key_structure(EN)
+
+
+def test_en_json_has_no_unresolved_key_references():
+    def walk(tree):
+        if isinstance(tree, dict):
+            for value in tree.values():
+                walk(value)
+        elif isinstance(tree, str):
+            assert "[%key:" not in tree, f"unresolved reference in en.json: {tree!r}"
+
+    walk(EN)
+
+
+def test_guidance_carriers_are_non_empty():
+    for path in GUIDANCE_KEYS:
+        assert _get(EN, path).strip(), f"empty guidance string at {path}"

--- a/tests/test_switch.py
+++ b/tests/test_switch.py
@@ -1,0 +1,113 @@
+"""Tests for the optimistic switch state machine.
+
+These drive the entity directly with a fake coordinator and a stubbed
+``async_write_ha_state`` so no full Home Assistant harness is required.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.voltcraft_sem6000_spb012ble.coordinator import VoltcraftData
+from custom_components.voltcraft_sem6000_spb012ble.protocol import SwitchModes
+from custom_components.voltcraft_sem6000_spb012ble.switch import MainSwitchEntity
+
+
+def _data(is_on: bool) -> VoltcraftData:
+    return VoltcraftData(
+        is_on=is_on,
+        power=0.0,
+        voltage=230.0,
+        current=0.0,
+        frequency=50,
+        power_factor=None,
+        consumed_energy=0.0,
+    )
+
+
+def _make_entity(measurement_count: int = 0, data: VoltcraftData | None = None) -> MainSwitchEntity:
+    coordinator = MagicMock()
+    coordinator.mac = "aa:bb:cc:dd:ee:ff"
+    coordinator.device_info = {}
+    coordinator.measurement_count = measurement_count
+    coordinator.data = data
+    coordinator.async_send_switch_command = AsyncMock()
+    coordinator.async_request_refresh = AsyncMock()
+    entity = MainSwitchEntity(coordinator)
+    entity.async_write_ha_state = MagicMock()
+    return entity
+
+
+async def test_optimistic_set_before_first_measurement():
+    entity = _make_entity(measurement_count=0, data=None)
+    await entity.async_turn_on()
+    assert entity.is_on is True
+    entity.coordinator.async_send_switch_command.assert_awaited_once_with(SwitchModes.ON)
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+
+
+async def test_optimistic_not_set_when_command_fails():
+    entity = _make_entity(measurement_count=0, data=None)
+    entity.coordinator.async_send_switch_command = AsyncMock(side_effect=HomeAssistantError("ble down"))
+    with pytest.raises(HomeAssistantError):
+        await entity.async_turn_on()
+    assert entity._optimistic_is_on is None  # no fabricated state on failure
+    entity.async_write_ha_state.assert_not_called()
+    entity.coordinator.async_request_refresh.assert_not_awaited()
+
+
+async def test_optimistic_overrides_device_until_confirmed():
+    entity = _make_entity(measurement_count=5, data=_data(False))
+    await entity.async_turn_off()
+    entity.coordinator.async_send_switch_command.assert_awaited_once_with(SwitchModes.OFF)
+    assert entity.is_on is False  # optimistic False overrides the device value
+    entity.coordinator.data = _data(True)
+    assert entity.is_on is False  # still optimistic until a measurement confirms
+
+
+async def test_optimistic_cleared_by_confirming_measurement():
+    entity = _make_entity(measurement_count=1, data=None)
+    await entity.async_turn_on()
+    assert entity.is_on is True
+
+    # A measurement confirming the requested state clears optimism immediately.
+    entity.coordinator.measurement_count = 2
+    entity.coordinator.data = _data(True)
+    entity._handle_coordinator_update()
+    assert entity._optimistic_is_on is None
+    assert entity.is_on is True
+
+
+async def test_optimistic_not_cleared_by_single_stale_measurement():
+    """A poll already in flight at toggle time reports the pre-toggle state."""
+    entity = _make_entity(measurement_count=1, data=None)
+    await entity.async_turn_on()
+
+    entity.coordinator.measurement_count = 2  # one measurement (possibly the in-flight poll)
+    entity.coordinator.data = _data(False)
+    entity._handle_coordinator_update()
+    assert entity.is_on is True  # no ON -> OFF flicker
+
+
+async def test_optimistic_cleared_after_two_measurements_when_command_failed():
+    entity = _make_entity(measurement_count=1, data=None)
+    await entity.async_turn_on()
+
+    entity.coordinator.measurement_count = 3  # a definitely-post-toggle reading
+    entity.coordinator.data = _data(False)
+    entity._handle_coordinator_update()
+    assert entity._optimistic_is_on is None
+    assert entity.is_on is False  # real (failed) state surfaced
+
+
+async def test_optimistic_not_cleared_on_noop_update():
+    entity = _make_entity(measurement_count=1, data=None)
+    await entity.async_turn_on()
+
+    # Timeout-return-last-data: listeners notified but measurement_count unchanged.
+    entity.coordinator.data = _data(False)
+    entity._handle_coordinator_update()
+    assert entity.is_on is True


### PR DESCRIPTION
Architecture cleanup + reliability hardening of the integration, plus optional **PIN authentication**.

## PIN / authentication
Some SEM6000/SPB012BLE hardware/firmware requires a 4-digit PIN (BLE login command `0x17`) before it accepts MEASURE/SWITCH. PIN support is optional and covers the full lifecycle:

- **Protocol** — `LoginCommand.build_payload` / `normalize_pin` (PIN encoded digit-by-digit, verified byte-identical to the reference `0000` frame) and `LoginNotifyPayload` status parsing (real 10-byte success/failure frames).
- **Coordinator** — logs in once per (re)connect (not per poll), taking `config_entry` so an explicit login-**failure frame** raises `ConfigEntryAuthFailed` → HA reauth. A login **timeout** or write error stays transient (`UpdateFailed`, no false reauth); a malformed *stored* PIN maps to `ConfigEntryAuthFailed` instead of crashing the poll. Dedicated `LOGIN_TIMEOUT`; a gated one-time PIN-timeout log warning; idempotent `async_shutdown`.
- **Config flow** — optional PIN at setup, plus **reauth** (requires a correct PIN) and **reconfigure** (add / change / clear the PIN anytime, dismissing any pending reauth), sharing one validator.
- **UX** — `strings.json` + resolved `translations/en.json` (custom components don't resolve `[%key:]` at runtime); README documents that failure-frame firmware shows a reauth prompt and pauses polling, while silently-ignoring firmware just stays unavailable and keeps retrying — in either case set/verify/clear the PIN via Reconfigure.

## Bugs fixed
- **Stale data never went unavailable** — the poll now awaits the MEASURE response (`MEASURE_TIMEOUT`) instead of returning the previous notification; a device that stops responding is detected and entities go unavailable after `MAX_MISSED_UPDATES` consecutive misses.
- **No reconnect on BLE drop** — the coordinator owns lazy connect/reconnect (`_async_ensure_connected`) and tears down + re-establishes half-open links.
- **Stricter data parsing** — `from_data` rejects truncated frames and caps the energy slice at `data[10:14]`, so neither a truncated nor an over-length frame can spike the `TOTAL_INCREASING` energy total.
- **Switch optimistic update was a no-op** — now a dedicated `_optimistic_is_on` field the `is_on` property prefers, cleared only on a confirming or definitely-post-toggle measurement (no flicker; a genuinely failed command still surfaces).
- **`async_shutdown` skipped `super()`** — could fire a poll after unload; now cancels the scheduled refresh.
- **Hung writes / start_notify** — all GATT ops bounded by `asyncio.timeout`.
- **Concurrency** — `_operation_lock` serializes GATT writes; identity-safe teardown won't null a concurrently-installed client; double-checked connect lock prevents duplicate connections.
- Setup raises `ConfigEntryNotReady` cleanly; config-flow entry title is the bare device name (picker keeps the address); `iot_class` → `local_polling`.

## Cleanup
Dead checksum block removed; redundant `_latest_data` dropped; guarded-disconnect extracted to `_async_safe_disconnect`; comments trimmed to point at the owning docstring; CLAUDE.md synced.

## Tests + CI
`pytest-homeassistant-custom-component` suite covering protocol, coordinator state machine (reconnect / concurrency / login / reauth-wiring / timeout / cross-isolation), switch optimistic, config-flow (PIN / reauth / reconfigure), setup, end-to-end PIN recovery, and strings-sync. New CI `test` job; transitive bluetooth/usb test deps pinned (incl. `pycares<5`). `ruff format`, `ruff check`, `mypy`, and full `pytest` all pass.
